### PR TITLE
Add homepage logo and styling

### DIFF
--- a/src/assets/trt_logo.svg
+++ b/src/assets/trt_logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <circle cx="60" cy="60" r="50" fill="#003366"/>
+  <text x="60" y="70" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="45" fill="white">TRT</text>
+</svg>

--- a/src/index.css
+++ b/src/index.css
@@ -24,8 +24,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,18 +1,32 @@
-const Home = () => {
-  console.log('Rendering Home component');
+import logo from '../assets/trt_logo.svg';
+
+function Home() {
   return (
     <div
       style={{
         display: 'flex',
-        justifyContent: 'center',
+        flexDirection: 'column',
         alignItems: 'center',
-        height: '100vh',
-        fontSize: '2rem',
+        marginTop: '2rem',
       }}
     >
-      TRT Planner
+      <img
+        src={logo}
+        alt="TRT Planner Logo"
+        style={{ width: '120px', height: '120px' }}
+      />
+      <h1
+        style={{
+          fontFamily: 'Segoe UI, Tahoma, Geneva, Verdana, sans-serif',
+          color: '#003366',
+          fontSize: '2.5rem',
+          marginTop: '1rem',
+        }}
+      >
+        TRT Planner
+      </h1>
     </div>
   );
-};
+}
 
 export default Home;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+/* eslint import/no-extraneous-dependencies: ["error", { devDependencies: true }] */
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 


### PR DESCRIPTION
## Summary
- add simple TRT logo
- center title beneath logo in dark blue font
- remove default body centering
- allow dev deps in vite config for ESLint

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686080d744a0833185c96111c6da44e1