### PR TITLE
Add sidebar layout with routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-redux": "^9.2.0",
+        "react-router-dom": "^7.6.3",
         "redux-persist": "^6.0.0"
       },
       "devDependencies": {
@@ -2519,6 +2520,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5196,6 +5206,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.3.tgz",
+      "integrity": "sha512-zf45LZp5skDC6I3jDLXQUu0u26jtuP4lEGbc7BbdyxenBN1vJSTA18czM2D+h5qyMBuMrD+9uB+mU37HIoKGRA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.3.tgz",
+      "integrity": "sha512-DiWJm9qdUAmiJrVWaeJdu4TKu13+iB/8IEi0EW/XgaHCjW/vWGrwzup0GVvaMteuZjKnh5bEvJP/K0MDnzawHw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.6.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -5473,6 +5521,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-redux": "^9.2.0",
+    "react-router-dom": "^7.6.3",
     "redux-persist": "^6.0.0"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,26 @@
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import Sidebar from './layout/Sidebar';
 import Home from './pages/Home';
+import InjectionSchedule from './pages/InjectionSchedule';
+import TravelPlans from './pages/TravelPlans';
+import Config from './pages/Config';
 
-const App = () => {
-  return <Home />;
-};
+function App() {
+  return (
+    <Router>
+      <div style={{ display: 'flex' }}>
+        <Sidebar />
+        <main style={{ padding: '2rem', flexGrow: 1 }}>
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/schedule" element={<InjectionSchedule />} />
+            <Route path="/travel" element={<TravelPlans />} />
+            <Route path="/config" element={<Config />} />
+          </Routes>
+        </main>
+      </div>
+    </Router>
+  );
+}
 
 export default App;

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -1,0 +1,31 @@
+import { NavLink } from 'react-router-dom';
+import version from '../version';
+
+function Sidebar() {
+  return (
+    <div
+      style={{
+        width: '250px',
+        height: '100vh',
+        background: '#f5f5f5',
+        padding: '1rem',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        boxShadow: '2px 0 5px rgba(0,0,0,0.1)',
+      }}
+    >
+      <nav style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+        <NavLink to="/">🏠 Home</NavLink>
+        <NavLink to="/schedule">💉 Injection Schedule</NavLink>
+        <NavLink to="/travel">✈️ Travel Plans</NavLink>
+        <NavLink to="/config">⚙️ Config</NavLink>
+      </nav>
+      <div style={{ fontSize: '0.8rem', color: '#666' }}>
+        Version: {version}
+      </div>
+    </div>
+  );
+}
+
+export default Sidebar;

--- a/src/pages/Config.tsx
+++ b/src/pages/Config.tsx
@@ -1,0 +1,4 @@
+function Config() {
+  return <h2>Config</h2>;
+}
+export default Config;

--- a/src/pages/InjectionSchedule.tsx
+++ b/src/pages/InjectionSchedule.tsx
@@ -1,0 +1,4 @@
+function InjectionSchedule() {
+  return <h2>Injection Schedule</h2>;
+}
+export default InjectionSchedule;

--- a/src/pages/TravelPlans.tsx
+++ b/src/pages/TravelPlans.tsx
@@ -1,0 +1,4 @@
+function TravelPlans() {
+  return <h2>Travel Plans</h2>;
+}
+export default TravelPlans;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,2 @@
+const version = '0.0.0001';
+export default version;


### PR DESCRIPTION
## Summary
- add react-router-dom for routing
- show version from `src/version.ts`
- implement `Sidebar` component
- integrate sidebar routing in `App`
- stub pages for Injection Schedule, Travel Plans and Config

## Testing
- `npm run lint`
- `npm run format`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68608301c9788331b8fe032d8e15ea6c