### PR TITLE
Improve sidebar and home design

### DIFF
--- a/src/assets/bg_pattern.svg
+++ b/src/assets/bg_pattern.svg
@@ -1,0 +1,8 @@
+<svg width="40" height="40" xmlns="http://www.w3.org/2000/svg">
+  <g fill="none" fill-rule="evenodd">
+    <g fill="#f1f5f9" fill-opacity="0.4">
+      <path d="M0 39h39V0H0v39zm1-1V1h37v37H1z"/>
+      <path d="M20 0h1v40h-1zM0 20h40v1H0z"/>
+    </g>
+  </g>
+</svg>

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,5 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Inter', 'Segoe UI', sans-serif;
   line-height: 1.5;
   font-weight: 400;
 

--- a/src/layout/Sidebar.module.css
+++ b/src/layout/Sidebar.module.css
@@ -4,14 +4,15 @@
   left: 0;
   width: 250px;
   height: 100vh;
-  background: linear-gradient(180deg, #f9fbfd, #eaeff5);
-  box-shadow: 2px 0 8px rgba(0, 0, 0, 0.1);
+  background: linear-gradient(180deg, #1e293b, #334155);
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
   padding: 1rem;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   transition: transform 0.3s ease;
   border-radius: 0 8px 8px 0;
+  font-family: 'Inter', 'Segoe UI', sans-serif;
   z-index: 999;
 }
 
@@ -22,41 +23,61 @@
 .logoContainer {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 2rem;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.logoWrapper {
+  background: #ffffff;
+  padding: 0.5rem;
+  border-radius: 50%;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #ffffff;
 }
 
 .logo {
-  width: 32px;
-  height: 32px;
+  width: 40px;
+  height: 40px;
 }
 
 .nav {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 1rem;
 }
 
 .link {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  color: #333;
+  color: #f1f5f9;
   text-decoration: none;
   font-weight: 500;
   padding: 0.5rem;
   border-radius: 6px;
-  transition: background 0.2s, padding-left 0.2s;
+  transition: all 0.2s ease-in-out;
 }
 
 .link:hover {
-  background: rgba(0, 0, 0, 0.05);
+  background: #64748b;
   padding-left: 0.75rem;
+  transform: scale(1.05);
 }
 
 .active {
   font-weight: 700;
-  background: rgba(0, 0, 0, 0.1);
+  background: #e2e8f0;
+  color: #1e293b;
 }
 
 .version {

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -27,11 +27,17 @@ function Sidebar() {
       <aside className={`${styles.sidebar} ${!open ? styles.closed : ''}`}>
         <div>
           <div className={styles.logoContainer}>
-            <img src={logo} alt="logo" className={styles.logo} />
-            <h2>TRT Planner</h2>
+            <div className={styles.logoWrapper}>
+              <img src={logo} alt="logo" className={styles.logo} />
+            </div>
+            <h2 className={styles.title}>TRT Planner</h2>
           </div>
           <nav className={styles.nav}>
-            <NavLink to="/" className={linkClass} onClick={() => setOpen(false)}>
+            <NavLink
+              to="/"
+              className={linkClass}
+              onClick={() => setOpen(false)}
+            >
               <FaHome /> Home
             </NavLink>
             <NavLink

--- a/src/pages/Home.module.css
+++ b/src/pages/Home.module.css
@@ -1,0 +1,31 @@
+.home {
+  min-height: 100vh;
+  background:
+    url('../assets/bg_pattern.svg') repeat,
+    radial-gradient(circle at top, #ffffff, #f1f5f9);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+}
+
+.card {
+  background: white;
+  padding: 2rem;
+  border-radius: 1rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  text-align: center;
+}
+
+.logo {
+  width: 120px;
+  height: 120px;
+}
+
+.title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-top: 1rem;
+  color: #1e293b;
+  font-family: 'Inter', 'Segoe UI', sans-serif;
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,30 +1,13 @@
 import logo from '../assets/trt_logo.svg';
+import styles from './Home.module.css';
 
 function Home() {
   return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        marginTop: '2rem',
-      }}
-    >
-      <img
-        src={logo}
-        alt="TRT Planner Logo"
-        style={{ width: '120px', height: '120px' }}
-      />
-      <h1
-        style={{
-          fontFamily: 'Segoe UI, Tahoma, Geneva, Verdana, sans-serif',
-          color: '#003366',
-          fontSize: '2.5rem',
-          marginTop: '1rem',
-        }}
-      >
-        TRT Planner
-      </h1>
+    <div className={styles.home}>
+      <div className={styles.card}>
+        <img src={logo} alt="TRT Planner Logo" className={styles.logo} />
+        <h1 className={styles.title}>TRT Planner</h1>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- modernize sidebar colors, fonts and spacing
- style logo with circular background
- animate menu links and active state
- add home page background pattern and card design
- use Inter font globally

## Testing
- `npm run lint`
- `npm run format`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686087e257ec8331927f7cdcb2682108