### PR TITLE
Add config form and improve sidebar version

### DIFF
--- a/src/layout/Sidebar.module.css
+++ b/src/layout/Sidebar.module.css
@@ -81,9 +81,10 @@
 }
 
 .version {
-  font-size: 0.8rem;
-  color: #777;
+  font-size: 1rem;
+  color: #e2e8f0;
   text-align: center;
+  margin-top: 1rem;
 }
 
 .toggleButton {

--- a/src/pages/Config.module.css
+++ b/src/pages/Config.module.css
@@ -1,0 +1,49 @@
+.container {
+  background: #f9fafb;
+  padding: 2rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
+  font-family: 'Inter', 'Segoe UI', sans-serif;
+  max-width: 600px;
+}
+
+.formGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.label {
+  font-weight: 500;
+  color: #1e293b;
+}
+
+.input,
+.select {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.5rem;
+  font-size: 1rem;
+  font-family: inherit;
+  background: #fff;
+  transition:
+    box-shadow 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.input:focus,
+.select:focus {
+  outline: none;
+  border-color: #64748b;
+  box-shadow: 0 0 0 3px rgba(100, 116, 139, 0.3);
+}
+
+.select {
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='%2364768b'%3E%3Cpath fill-rule='evenodd' d='M5.23 7.21a.75.75 0 011.06.02L10 11.084l3.71-3.853a.75.75 0 111.08 1.04l-4.24 4.4a.75.75 0 01-1.08 0l-4.24-4.4a.75.75 0 01.02-1.06z' clip-rule='evenodd'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  background-size: 1rem;
+}

--- a/src/pages/Config.tsx
+++ b/src/pages/Config.tsx
@@ -1,4 +1,58 @@
+import { useState } from 'react';
+import styles from './Config.module.css';
+
 function Config() {
-  return <h2>Config</h2>;
+  const [name, setName] = useState('');
+  const [trt, setTrt] = useState('');
+  const [hcg, setHcg] = useState('');
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.formGroup}>
+        <label htmlFor="name" className={styles.label}>
+          Name
+          <input
+            id="name"
+            type="text"
+            placeholder="Enter your name"
+            className={styles.input}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </label>
+      </div>
+      <div className={styles.formGroup}>
+        <label htmlFor="trt" className={styles.label}>
+          Are you currently on TRT?
+          <select
+            id="trt"
+            className={styles.select}
+            value={trt}
+            onChange={(e) => setTrt(e.target.value)}
+          >
+            <option value="">Select</option>
+            <option value="Yes">Yes</option>
+            <option value="No">No</option>
+          </select>
+        </label>
+      </div>
+      <div className={styles.formGroup}>
+        <label htmlFor="hcg" className={styles.label}>
+          Are you currently on HCG?
+          <select
+            id="hcg"
+            className={styles.select}
+            value={hcg}
+            onChange={(e) => setHcg(e.target.value)}
+          >
+            <option value="">Select</option>
+            <option value="Yes">Yes</option>
+            <option value="No">No</option>
+          </select>
+        </label>
+      </div>
+    </div>
+  );
 }
+
 export default Config;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-const version = '0.0.0001';
+const version = '0.0.0002';
 export default version;


### PR DESCRIPTION
## Summary
- create modern Config form with inputs for user name, TRT, and HCG
- add styling for the Config page
- bump version to 0.0.0002 and enlarge sidebar version display

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68608aedd06c83318c1f084427889782