### PR TITLE
Unify sidebar toggle button style

### DIFF
--- a/src/layout/Sidebar.module.css
+++ b/src/layout/Sidebar.module.css
@@ -93,11 +93,11 @@
   left: 1rem;
   width: 40px;
   height: 40px;
-  border: 2px solid #646cff;
+  border: none;
   border-radius: 50%;
-  background: #fff;
-  color: #646cff;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  background: #003366;
+  color: #ffffff;
+  box-shadow: rgba(0, 0, 0, 0.2) 0px 2px 6px;
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -110,7 +110,7 @@
 }
 
 .toggleButton:hover {
-  background: #e2e8f0;
+  background: #002244;
   transform: scale(1.05);
 }
 

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { NavLink } from 'react-router-dom';
-import { FaHome, FaSyringe, FaPlane, FaCog, FaBars } from 'react-icons/fa';
+import { FaHome, FaSyringe, FaPlane, FaCog } from 'react-icons/fa';
+import { MdMenu } from 'react-icons/md';
 import version from '../version';
 import logo from '../assets/trt_logo.svg';
 import styles from './Sidebar.module.css';
@@ -22,7 +23,7 @@ function Sidebar() {
         onClick={toggle}
         className={`${styles.toggleButton} ${open ? styles.buttonOpen : ''}`}
       >
-        <FaBars />
+        <MdMenu />
       </button>
       <aside className={`${styles.sidebar} ${!open ? styles.closed : ''}`}>
         <div>


### PR DESCRIPTION
## Summary
- restyle sidebar toggle button in CSS
- use MdMenu icon for the toggle button

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68615dff601c833192e831fdf8fa851a