### PR TITLE
Improve sidebar toggle design

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.eslintcache

--- a/src/layout/Sidebar.module.css
+++ b/src/layout/Sidebar.module.css
@@ -81,18 +81,23 @@
 }
 
 .version {
-  font-size: 1rem;
-  color: #e2e8f0;
-  text-align: center;
-  margin-top: 1rem;
+  position: absolute;
+  bottom: 1rem;
+  left: 1rem;
+  font-size: 0.875rem;
+  color: #ffffff;
+  font-style: italic;
+  border-top: 1px solid #475569;
+  padding-top: 0.5rem;
+  width: calc(100% - 2rem);
 }
 
 .toggleButton {
   position: fixed;
   top: 1rem;
   left: 1rem;
-  width: 48px;
-  height: 48px;
+  width: 56px;
+  height: 56px;
   border: 2px solid #ffffff;
   border-radius: 50%;
   background: #1e293b;
@@ -121,6 +126,10 @@
 
 .icon {
   color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.25rem;
   transition: transform 0.3s ease;
 }
 

--- a/src/layout/Sidebar.module.css
+++ b/src/layout/Sidebar.module.css
@@ -120,6 +120,7 @@
 }
 
 .icon {
+  color: #ffffff;
   transition: transform 0.3s ease;
 }
 

--- a/src/layout/Sidebar.module.css
+++ b/src/layout/Sidebar.module.css
@@ -91,11 +91,11 @@
   position: fixed;
   top: 1rem;
   left: 1rem;
-  width: 40px;
-  height: 40px;
-  border: none;
+  width: 48px;
+  height: 48px;
+  border: 2px solid #ffffff;
   border-radius: 50%;
-  background: #003366;
+  background: #1e293b;
   color: #ffffff;
   box-shadow: rgba(0, 0, 0, 0.2) 0px 2px 6px;
   cursor: pointer;
@@ -110,10 +110,19 @@
 }
 
 .toggleButton:hover {
-  background: #002244;
+  background: #334155;
+  box-shadow: rgba(0, 0, 0, 0.3) 0px 4px 8px;
   transform: scale(1.05);
 }
 
 .buttonOpen {
   left: 260px;
+}
+
+.icon {
+  transition: transform 0.3s ease;
+}
+
+.iconOpen {
+  transform: rotate(180deg);
 }

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -26,11 +26,10 @@ function Sidebar() {
         {open ? (
           <MdClose
             className={`${styles.icon} ${styles.iconOpen}`}
-            size="2rem"
             color="white"
           />
         ) : (
-          <MdMenu className={styles.icon} size="2rem" color="white" />
+          <MdMenu className={styles.icon} color="white" />
         )}
       </button>
       <aside className={`${styles.sidebar} ${!open ? styles.closed : ''}`}>

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -26,10 +26,11 @@ function Sidebar() {
         {open ? (
           <MdClose
             className={`${styles.icon} ${styles.iconOpen}`}
-            size="1.75rem"
+            size="2rem"
+            color="white"
           />
         ) : (
-          <MdMenu className={styles.icon} size="1.75rem" />
+          <MdMenu className={styles.icon} size="2rem" color="white" />
         )}
       </button>
       <aside className={`${styles.sidebar} ${!open ? styles.closed : ''}`}>

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import { FaHome, FaSyringe, FaPlane, FaCog } from 'react-icons/fa';
-import { MdMenu } from 'react-icons/md';
+import { MdMenu, MdClose } from 'react-icons/md';
 import version from '../version';
 import logo from '../assets/trt_logo.svg';
 import styles from './Sidebar.module.css';
@@ -23,7 +23,14 @@ function Sidebar() {
         onClick={toggle}
         className={`${styles.toggleButton} ${open ? styles.buttonOpen : ''}`}
       >
-        <MdMenu />
+        {open ? (
+          <MdClose
+            className={`${styles.icon} ${styles.iconOpen}`}
+            size="1.75rem"
+          />
+        ) : (
+          <MdMenu className={styles.icon} size="1.75rem" />
+        )}
       </button>
       <aside className={`${styles.sidebar} ${!open ? styles.closed : ''}`}>
         <div>


### PR DESCRIPTION
## Summary
- revamp sidebar toggle button style
- switch between menu and close icons with rotation animation

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6861606551648331b5e8405e47012944