### PR TITLE
Add configurable form with title

### DIFF
--- a/src/pages/Config.module.css
+++ b/src/pages/Config.module.css
@@ -47,3 +47,38 @@
   background-position: right 0.75rem center;
   background-size: 1rem;
 }
+
+.pageTitle {
+  display: flex;
+  align-items: center;
+  margin-left: calc(56px + 1rem + 12px);
+  margin-top: 1rem;
+  margin-bottom: 1.5rem;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.saveButton {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  background: #1e293b;
+  color: #ffffff;
+  border: none;
+  border-radius: 0.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.saveButton:hover {
+  background: #334155;
+}
+
+.savedMessage {
+  margin-top: 0.75rem;
+  color: #16a34a;
+  font-weight: 500;
+  text-align: center;
+}

--- a/src/pages/Config.tsx
+++ b/src/pages/Config.tsx
@@ -1,57 +1,88 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import styles from './Config.module.css';
 
 function Config() {
   const [name, setName] = useState('');
   const [trt, setTrt] = useState('');
   const [hcg, setHcg] = useState('');
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('configSettings');
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored);
+        setName(parsed.name ?? '');
+        setTrt(parsed.trt ?? '');
+        setHcg(parsed.hcg ?? '');
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error('Failed to parse settings', e);
+      }
+    }
+  }, []);
+
+  const handleSave = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const data = { name, trt, hcg };
+    localStorage.setItem('configSettings', JSON.stringify(data));
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+  };
 
   return (
-    <div className={styles.container}>
-      <div className={styles.formGroup}>
-        <label htmlFor="name" className={styles.label}>
-          Name
-          <input
-            id="name"
-            type="text"
-            placeholder="Enter your name"
-            className={styles.input}
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-          />
-        </label>
-      </div>
-      <div className={styles.formGroup}>
-        <label htmlFor="trt" className={styles.label}>
-          Are you currently on TRT?
-          <select
-            id="trt"
-            className={styles.select}
-            value={trt}
-            onChange={(e) => setTrt(e.target.value)}
-          >
-            <option value="">Select</option>
-            <option value="Yes">Yes</option>
-            <option value="No">No</option>
-          </select>
-        </label>
-      </div>
-      <div className={styles.formGroup}>
-        <label htmlFor="hcg" className={styles.label}>
-          Are you currently on HCG?
-          <select
-            id="hcg"
-            className={styles.select}
-            value={hcg}
-            onChange={(e) => setHcg(e.target.value)}
-          >
-            <option value="">Select</option>
-            <option value="Yes">Yes</option>
-            <option value="No">No</option>
-          </select>
-        </label>
-      </div>
-    </div>
+    <>
+      <h1 className={styles.pageTitle}>General Configuration</h1>
+      <form className={styles.container} onSubmit={handleSave}>
+        <div className={styles.formGroup}>
+          <label htmlFor="name" className={styles.label}>
+            Name
+            <input
+              id="name"
+              type="text"
+              placeholder="Enter your name"
+              className={styles.input}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </label>
+        </div>
+        <div className={styles.formGroup}>
+          <label htmlFor="trt" className={styles.label}>
+            Are you currently on TRT?
+            <select
+              id="trt"
+              className={styles.select}
+              value={trt}
+              onChange={(e) => setTrt(e.target.value)}
+            >
+              <option value="">Select</option>
+              <option value="Yes">Yes</option>
+              <option value="No">No</option>
+            </select>
+          </label>
+        </div>
+        <div className={styles.formGroup}>
+          <label htmlFor="hcg" className={styles.label}>
+            Are you currently on HCG?
+            <select
+              id="hcg"
+              className={styles.select}
+              value={hcg}
+              onChange={(e) => setHcg(e.target.value)}
+            >
+              <option value="">Select</option>
+              <option value="Yes">Yes</option>
+              <option value="No">No</option>
+            </select>
+          </label>
+        </div>
+        <button type="submit" className={styles.saveButton}>
+          Save
+        </button>
+        {saved && <div className={styles.savedMessage}>Settings saved!</div>}
+      </form>
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- add page title to Config page
- convert Config page inputs to a form
- persist settings to `localStorage`
- style save button and success message

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68616913ca70833190bfa82e62e69e48