### PR TITLE
Add dynamic injectables config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+## Changelog
+
+- 2025-06-29 20:11 · Unspecified task · v0.0.0004
+- 2025-06-29 20:14 · Extend Config page to record injectables · v0.0.0005

--- a/README.md
+++ b/README.md
@@ -21,3 +21,8 @@ npm run format    # run Prettier
 ```
 
 The application will display `Welcome to TRT Planner` and persist state across reloads.
+
+## Changelog
+
+- 2025-06-29 20:11 · Unspecified task · v0.0.0004
+- 2025-06-29 20:14 · Extend Config page to record injectables · v0.0.0005

--- a/src/pages/Config.module.css
+++ b/src/pages/Config.module.css
@@ -72,6 +72,24 @@
   transition: background-color 0.2s ease;
 }
 
+.addButton {
+  width: 100%;
+  padding: 0.5rem 1rem;
+  background: #e2e8f0;
+  color: #1e293b;
+  border: none;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  margin-bottom: 1.5rem;
+  transition: background-color 0.2s ease;
+}
+
+.addButton:hover {
+  background: #cbd5e1;
+}
+
 .saveButton:hover {
   background: #334155;
 }

--- a/src/pages/Config.tsx
+++ b/src/pages/Config.tsx
@@ -5,7 +5,23 @@ function Config() {
   const [name, setName] = useState('');
   const [trt, setTrt] = useState('');
   const [hcg, setHcg] = useState('');
+  const [injectablesEnabled, setInjectablesEnabled] = useState('');
+  const [injectables, setInjectables] = useState<{ name: string }[]>([]);
   const [saved, setSaved] = useState(false);
+
+  const handleInjectablesEnabledChange = (value: string) => {
+    setInjectablesEnabled(value);
+    if (value === 'Yes' && injectables.length === 0) {
+      setInjectables([{ name: '' }]);
+    }
+    if (value !== 'Yes') {
+      setInjectables([]);
+    }
+  };
+
+  const addInjectable = () => {
+    setInjectables([...injectables, { name: '' }]);
+  };
 
   useEffect(() => {
     const stored = localStorage.getItem('configSettings');
@@ -15,6 +31,8 @@ function Config() {
         setName(parsed.name ?? '');
         setTrt(parsed.trt ?? '');
         setHcg(parsed.hcg ?? '');
+        setInjectablesEnabled(parsed.injectablesEnabled ?? '');
+        setInjectables(parsed.injectables ?? []);
       } catch (e) {
         // eslint-disable-next-line no-console
         console.error('Failed to parse settings', e);
@@ -24,7 +42,13 @@ function Config() {
 
   const handleSave = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const data = { name, trt, hcg };
+    const data = {
+      name,
+      trt,
+      hcg,
+      injectablesEnabled,
+      injectables,
+    };
     localStorage.setItem('configSettings', JSON.stringify(data));
     setSaved(true);
     setTimeout(() => setSaved(false), 2000);
@@ -77,6 +101,51 @@ function Config() {
             </select>
           </label>
         </div>
+        <div className={styles.formGroup}>
+          <label htmlFor="injectablesEnabled" className={styles.label}>
+            Are you taking any of the peptides or injectables you wish recorded?
+            <select
+              id="injectablesEnabled"
+              className={styles.select}
+              value={injectablesEnabled}
+              onChange={(e) => handleInjectablesEnabledChange(e.target.value)}
+            >
+              <option value="">Select</option>
+              <option value="Yes">Yes</option>
+              <option value="No">No</option>
+            </select>
+          </label>
+        </div>
+        {injectablesEnabled === 'Yes' && (
+          <>
+            {injectables.map((inj, idx) => (
+              // eslint-disable-next-line react/no-array-index-key
+              <div className={styles.formGroup} key={idx}>
+                <label htmlFor={`inj-${idx}`} className={styles.label}>
+                  {`${idx + 1}. Name`}
+                  <input
+                    id={`inj-${idx}`}
+                    type="text"
+                    className={styles.input}
+                    value={inj.name}
+                    onChange={(e) => {
+                      const updated = [...injectables];
+                      updated[idx].name = e.target.value;
+                      setInjectables(updated);
+                    }}
+                  />
+                </label>
+              </div>
+            ))}
+            <button
+              type="button"
+              className={styles.addButton}
+              onClick={addInjectable}
+            >
+              Add another
+            </button>
+          </>
+        )}
         <button type="submit" className={styles.saveButton}>
           Save
         </button>

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-const version = '0.0.0003';
+const version = '0.0.0005';
 export default version;


### PR DESCRIPTION
## Summary
- extend Config page to record injectables
- style new injectable inputs and Add button
- save new settings to localStorage
- bump version to 0.0.0005
- document change in README and CHANGELOG

## Testing
- `npm run lint`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_68619dca83908331b1005fc696fd7a43