### PR TITLE
Improve layout and UI for dynamic injectable list on Config page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,5 @@
 - 2025-06-29 20:14 · Extend Config page to record injectables · v0.0.0005
 - 2025-06-29 20:54 · Unspecified task · v0.0.0006
 - 2025-06-29 21:09 · Unspecified task · v0.0.0008
+- 2025-06-29 21:26 · Unspecified task · v0.0.0009
+- 2025-06-29 21:26 · Improve layout and UI for dynamic injectable list on Config page · v0.0.0010

--- a/README.md
+++ b/README.md
@@ -28,3 +28,5 @@ The application will display `Welcome to TRT Planner` and persist state across r
 - 2025-06-29 20:14 · Extend Config page to record injectables · v0.0.0005
 - 2025-06-29 20:54 · Unspecified task · v0.0.0006
 - 2025-06-29 21:09 · Unspecified task · v0.0.0008
+- 2025-06-29 21:26 · Unspecified task · v0.0.0009
+- 2025-06-29 21:26 · Improve layout and UI for dynamic injectable list on Config page · v0.0.0010

--- a/src/pages/Config.module.css
+++ b/src/pages/Config.module.css
@@ -104,13 +104,16 @@
 .injectableRow {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.75rem;
   margin-bottom: 0.75rem;
 }
 
 .rowIndex {
   width: 1.5rem;
   text-align: right;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
 }
 
 .injectableInput {
@@ -119,7 +122,7 @@
 
 .injectableActions {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.25rem;
   margin-left: 0.5rem;
 }
 
@@ -139,6 +142,23 @@
 }
 
 .smallButton:hover {
+  background: #cbd5e1;
+}
+
+.iconButton {
+  background: #e2e8f0;
+  color: #1e293b;
+  border: none;
+  border-radius: 0.375rem;
+  padding: 0.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.iconButton:hover {
   background: #cbd5e1;
 }
 

--- a/src/pages/Config.tsx
+++ b/src/pages/Config.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react';
+import { GiSightDisabled } from 'react-icons/gi';
+import { FaRegTrashAlt } from 'react-icons/fa';
 import styles from './Config.module.css';
 
 interface Injectable {
@@ -190,17 +192,19 @@ function Config() {
                 <div className={styles.injectableActions}>
                   <button
                     type="button"
-                    className={styles.smallButton}
+                    className={styles.iconButton}
                     onClick={() => toggleDisable(idx)}
+                    aria-label={inj.disabled ? 'Enable injectable' : 'Disable injectable'}
                   >
-                    {inj.disabled ? 'Enable' : 'Disable'}
+                    <GiSightDisabled />
                   </button>
                   <button
                     type="button"
-                    className={styles.smallButton}
+                    className={styles.iconButton}
                     onClick={() => deleteInjectable(idx)}
+                    aria-label="Delete injectable"
                   >
-                    Delete
+                    <FaRegTrashAlt />
                   </button>
                 </div>
               </div>

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-const version = '0.0.0008';
+const version = '0.0.0010';
 export default version;


### PR DESCRIPTION
## Summary
- polish injectable section in Config page
- add icons for disable and delete actions
- tweak styles for better alignment
- bump version to 0.0.0010

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6861af602b2083319d73f45d46726a8e