### PR TITLE
Add Delete All config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,5 @@
 - 2025-06-29 21:26 · Improve layout and UI for dynamic injectable list on Config page · v0.0.0010
 - 2025-06-29 21:47 · Unspecified task · v0.0.0011
 - 2025-06-29 22:03 · Improve layout and UI for dynamic injectable list on Config page · v0.0.0012
+- 2025-06-29 22:02 · Unspecified task · v0.0.0013
+- 2025-06-29 22:11 · Add Delete All button with confirmation to clear config and injectable data · v0.0.0014

--- a/README.md
+++ b/README.md
@@ -32,3 +32,5 @@ The application will display `Welcome to TRT Planner` and persist state across r
 - 2025-06-29 21:26 · Improve layout and UI for dynamic injectable list on Config page · v0.0.0010
 - 2025-06-29 21:47 · Unspecified task · v0.0.0011
 - 2025-06-29 22:03 · Improve layout and UI for dynamic injectable list on Config page · v0.0.0012
+- 2025-06-29 22:02 · Unspecified task · v0.0.0013
+- 2025-06-29 22:11 · Add Delete All button with confirmation to clear config and injectable data · v0.0.0014

--- a/src/pages/Config.module.css
+++ b/src/pages/Config.module.css
@@ -170,3 +170,26 @@
   color: #64748b;
   font-size: 1rem;
 }
+
+.deleteSection {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid #e5e7eb;
+}
+
+.deleteButton {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  background: #dc2626;
+  color: #ffffff;
+  border: none;
+  border-radius: 0.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.deleteButton:hover {
+  background: #b91c1c;
+}

--- a/src/pages/Config.tsx
+++ b/src/pages/Config.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { GiSightDisabled } from 'react-icons/gi';
-import { FaRegTrashAlt } from 'react-icons/fa';
+import { FaRegTrashAlt, FaExclamationTriangle } from 'react-icons/fa';
 import styles from './Config.module.css';
 
 interface Injectable {
@@ -105,6 +105,26 @@ function Config() {
     localStorage.setItem('configSettings', JSON.stringify(data));
     setSaved(true);
     setTimeout(() => setSaved(false), 2000);
+  };
+
+  const handleDeleteAll = () => {
+    // eslint-disable-next-line no-alert
+    if (
+      window.confirm(
+        'This will permanently delete all saved configuration and injectable data. Are you sure you want to continue?',
+      )
+    ) {
+      localStorage.removeItem('configSettings');
+      localStorage.removeItem('injectables');
+      localStorage.removeItem('persist:root');
+      setName('');
+      setTrt('');
+      setHcg('');
+      setInjectablesEnabled('');
+      setInjectables([]);
+      // eslint-disable-next-line no-alert
+      window.alert('All data deleted.');
+    }
   };
 
   return (
@@ -229,6 +249,19 @@ function Config() {
           Save
         </button>
         {saved && <div className={styles.savedMessage}>Settings saved!</div>}
+        <div className={styles.deleteSection}>
+          <button
+            type="button"
+            className={styles.deleteButton}
+            onClick={handleDeleteAll}
+          >
+            <FaExclamationTriangle
+              size={20}
+              style={{ marginRight: '0.5rem' }}
+            />
+            Delete All
+          </button>
+        </div>
       </form>
     </>
   );

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-const version = '0.0.0012';
+const version = '0.0.0014';
 export default version;


### PR DESCRIPTION
## Summary
- add confirmation-driven `Delete All` function on Config page
- style Delete All button as destructive
- bump version to 0.0.0014
- document changes in CHANGELOG and README

## Testing
- `npm run lint`
- `npm run format`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861b7a47200833185a3c1b150c7dcac