### PR TITLE
Align Injection Schedule layout with Config styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,5 @@
 - 2025-06-29 22:11 · Add Delete All button with confirmation to clear config and injectable data · v0.0.0014
 - 2025-06-29 22:17 · Unspecified task · v0.0.0015
 - 2025-06-29 22:18 · Simplify config layout and add oral medication support · v0.0.0016
+- 2025-06-29 22:34 · Unspecified task · v0.0.0017
+- 2025-06-29 22:46 · Align Injection Schedule layout with General Configuration styling · v0.0.0018

--- a/README.md
+++ b/README.md
@@ -36,3 +36,5 @@ The application will display `Welcome to TRT Planner` and persist state across r
 - 2025-06-29 22:11 · Add Delete All button with confirmation to clear config and injectable data · v0.0.0014
 - 2025-06-29 22:17 · Unspecified task · v0.0.0015
 - 2025-06-29 22:18 · Simplify config layout and add oral medication support · v0.0.0016
+- 2025-06-29 22:34 · Unspecified task · v0.0.0017
+- 2025-06-29 22:46 · Align Injection Schedule layout with General Configuration styling · v0.0.0018

--- a/src/pages/InjectionSchedule.module.css
+++ b/src/pages/InjectionSchedule.module.css
@@ -1,0 +1,202 @@
+.container {
+  background: #f9fafb;
+  padding: 2rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
+  font-family: 'Inter', 'Segoe UI', sans-serif;
+  max-width: 600px;
+}
+
+.formGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.label {
+  font-weight: 500;
+  color: #1e293b;
+}
+
+.input,
+.select {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.5rem;
+  font-size: 1rem;
+  font-family: inherit;
+  background: #fff;
+  transition:
+    box-shadow 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.input:focus,
+.select:focus {
+  outline: none;
+  border-color: #64748b;
+  box-shadow: 0 0 0 3px rgba(100, 116, 139, 0.3);
+}
+
+.select {
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='%2364768b'%3E%3Cpath fill-rule='evenodd' d='M5.23 7.21a.75.75 0 011.06.02L10 11.084l3.71-3.853a.75.75 0 111.08 1.04l-4.24 4.4a.75.75 0 01-1.08 0l-4.24-4.4a.75.75 0 01.02-1.06z' clip-rule='evenodd'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  background-size: 1rem;
+}
+
+.pageTitle {
+  display: flex;
+  align-items: center;
+  margin-left: calc(56px + 1rem + 8px);
+  margin-top: 1rem;
+  margin-bottom: 2rem;
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #1e293b;
+}
+
+.sectionTitle {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #1e293b;
+  margin: 1rem 0 0.5rem;
+}
+
+.saveButton {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  background: #1e293b;
+  color: #ffffff;
+  border: none;
+  border-radius: 0.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.addButton {
+  width: 100%;
+  padding: 0.5rem 1rem;
+  background: #e2e8f0;
+  color: #1e293b;
+  border: none;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  margin-bottom: 1.5rem;
+  transition: background-color 0.2s ease;
+}
+
+.addButton:hover {
+  background: #cbd5e1;
+}
+
+.saveButton:hover {
+  background: #334155;
+}
+
+.savedMessage {
+  margin-top: 0.75rem;
+  color: #16a34a;
+  font-weight: 500;
+  text-align: center;
+}
+
+.injectableRow {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.rowIndex {
+  width: 1.5rem;
+  text-align: right;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.injectableInput {
+  flex: 1;
+}
+
+.injectableActions {
+  display: flex;
+  gap: 0.25rem;
+  margin-left: 0.5rem;
+}
+
+.disabledInput {
+  opacity: 0.5;
+}
+
+.smallButton {
+  background: #e2e8f0;
+  color: #1e293b;
+  border: none;
+  border-radius: 0.375rem;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.smallButton:hover {
+  background: #cbd5e1;
+}
+
+.iconButton {
+  background: #e2e8f0;
+  color: #1e293b;
+  border: none;
+  border-radius: 0.375rem;
+  padding: 0.25rem;
+  width: 2rem;
+  height: 2rem;
+  font-size: 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.iconButton:hover {
+  background: #cbd5e1;
+}
+
+.dragHandle {
+  cursor: move;
+  color: #64748b;
+  font-size: 1rem;
+}
+
+.deleteSection {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid #e5e7eb;
+}
+
+.deleteButton {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  background: #dc2626;
+  color: #ffffff;
+  border: none;
+  border-radius: 0.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.deleteButton:hover {
+  background: #b91c1c;
+}

--- a/src/pages/InjectionSchedule.tsx
+++ b/src/pages/InjectionSchedule.tsx
@@ -1,4 +1,138 @@
-function InjectionSchedule() {
-  return <h2>Injection Schedule</h2>;
+import { useEffect, useState } from 'react';
+import { GiSightDisabled } from 'react-icons/gi';
+import { FaRegTrashAlt } from 'react-icons/fa';
+import styles from './InjectionSchedule.module.css';
+
+interface ScheduleEntry {
+  medication: string;
+  date: string;
+  disabled?: boolean;
 }
+
+function InjectionSchedule() {
+  const [entries, setEntries] = useState<ScheduleEntry[]>([]);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('injectionSchedule');
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) {
+          setEntries(
+            parsed.map((e: ScheduleEntry) => ({
+              medication: e.medication ?? '',
+              date: e.date ?? '',
+              disabled: e.disabled ?? false,
+            })),
+          );
+        }
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error('Failed to parse schedule', err);
+      }
+    }
+  }, []);
+
+  const handleMedicationChange = (idx: number, value: string) => {
+    const updated = [...entries];
+    updated[idx].medication = value;
+    setEntries(updated);
+  };
+
+  const handleDateChange = (idx: number, value: string) => {
+    const updated = [...entries];
+    updated[idx].date = value;
+    setEntries(updated);
+  };
+
+  const addEntry = () => {
+    setEntries([...entries, { medication: '', date: '', disabled: false }]);
+  };
+
+  const toggleDisable = (idx: number) => {
+    const updated = [...entries];
+    updated[idx].disabled = !updated[idx].disabled;
+    setEntries(updated);
+  };
+
+  const deleteEntry = (idx: number) => {
+    // eslint-disable-next-line no-alert
+    if (window.confirm('Are you sure you want to delete this entry?')) {
+      setEntries((prev) => {
+        const updated = [...prev];
+        updated.splice(idx, 1);
+        return updated;
+      });
+    }
+  };
+
+  const handleSave = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    localStorage.setItem('injectionSchedule', JSON.stringify(entries));
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+  };
+
+  return (
+    <>
+      <h1 className={styles.pageTitle}>Injection Schedule</h1>
+      <form className={styles.container} onSubmit={handleSave}>
+        {entries.map((entry, idx) => (
+          <div
+            key={idx} // eslint-disable-line react/no-array-index-key
+            className={styles.injectableRow}
+          >
+            <span className={styles.rowIndex}>{`${idx + 1}.`}</span>
+            <input
+              type="text"
+              placeholder="Medication"
+              className={`${styles.input} ${styles.injectableInput} ${
+                entry.disabled ? styles.disabledInput : ''
+              }`}
+              value={entry.medication}
+              disabled={entry.disabled}
+              onChange={(e) => handleMedicationChange(idx, e.target.value)}
+            />
+            <input
+              type="date"
+              className={`${styles.input} ${styles.injectableInput} ${
+                entry.disabled ? styles.disabledInput : ''
+              }`}
+              value={entry.date}
+              disabled={entry.disabled}
+              onChange={(e) => handleDateChange(idx, e.target.value)}
+            />
+            <div className={styles.injectableActions}>
+              <button
+                type="button"
+                className={styles.iconButton}
+                onClick={() => toggleDisable(idx)}
+                aria-label={entry.disabled ? 'Enable entry' : 'Disable entry'}
+              >
+                <GiSightDisabled size={20} />
+              </button>
+              <button
+                type="button"
+                className={styles.iconButton}
+                onClick={() => deleteEntry(idx)}
+                aria-label="Delete entry"
+              >
+                <FaRegTrashAlt size={20} />
+              </button>
+            </div>
+          </div>
+        ))}
+        <button type="button" className={styles.addButton} onClick={addEntry}>
+          Add another
+        </button>
+        <button type="submit" className={styles.saveButton}>
+          Save
+        </button>
+        {saved && <div className={styles.savedMessage}>Schedule saved!</div>}
+      </form>
+    </>
+  );
+}
+
 export default InjectionSchedule;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-const version = '0.0.0016';
+const version = '0.0.0018';
 export default version;


### PR DESCRIPTION
## Summary
- style InjectionSchedule page like Config layout
- create `InjectionSchedule.module.css`
- version bump to 0.0.0018
- document changes

## Testing
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6861bf3325188331af6b3ae3fb7574c6