### PR TITLE
Add info button linking to Wikipedia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,5 @@
 - 2025-06-29 22:49 · Add Oral Schedule page and conditional sidebar visibility based on enabled medications · v0.0.0020
 - 2025-06-29 22:56 · Unspecified task · v0.0.0021
 - 2025-06-29 22:59 · Conditionally display schedule pages in sidebar based on enabled medication entries · v0.0.0022
+- 2025-06-29 23:10 · Unspecified task · v0.0.0023
+- 2025-06-29 23:12 · Add Wikipedia info button to injectable and oral medication inputs · v0.0.0024

--- a/README.md
+++ b/README.md
@@ -42,3 +42,5 @@ The application will display `Welcome to TRT Planner` and persist state across r
 - 2025-06-29 22:49 · Add Oral Schedule page and conditional sidebar visibility based on enabled medications · v0.0.0020
 - 2025-06-29 22:56 · Unspecified task · v0.0.0021
 - 2025-06-29 22:59 · Conditionally display schedule pages in sidebar based on enabled medication entries · v0.0.0022
+- 2025-06-29 23:10 · Unspecified task · v0.0.0023
+- 2025-06-29 23:12 · Add Wikipedia info button to injectable and oral medication inputs · v0.0.0024

--- a/src/pages/Config.module.css
+++ b/src/pages/Config.module.css
@@ -172,6 +172,11 @@
   background: #cbd5e1;
 }
 
+.iconButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .dragHandle {
   cursor: move;
   color: #64748b;

--- a/src/pages/Config.tsx
+++ b/src/pages/Config.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { GiSightDisabled } from 'react-icons/gi';
 import { FaRegTrashAlt, FaExclamationTriangle } from 'react-icons/fa';
+import { FiInfo } from 'react-icons/fi';
 import styles from './Config.module.css';
 
 interface Medication {
@@ -15,7 +16,6 @@ function Config() {
   const [injDragIndex, setInjDragIndex] = useState<number | null>(null);
   const [oralDragIndex, setOralDragIndex] = useState<number | null>(null);
   const [saved, setSaved] = useState(false);
-
 
   const addInjectable = () => {
     setInjectables([...injectables, { name: '', disabled: false }]);
@@ -95,6 +95,13 @@ function Config() {
     updated.splice(index, 0, moved);
     setOrals(updated);
     setOralDragIndex(null);
+  };
+
+  const openWikipedia = (med: string) => {
+    const query = med.trim();
+    if (!query) return;
+    const url = `https://en.wikipedia.org/wiki/Special:Search?search=${encodeURIComponent(query)}`;
+    window.open(url, '_blank', 'noopener,noreferrer');
   };
 
   useEffect(() => {
@@ -216,6 +223,16 @@ function Config() {
               <button
                 type="button"
                 className={styles.iconButton}
+                onClick={() => openWikipedia(inj.name)}
+                aria-label={`Search Wikipedia for ${inj.name}`}
+                title={`Search Wikipedia for ${inj.name}`}
+                disabled={!inj.name.trim()}
+              >
+                <FiInfo size={20} />
+              </button>
+              <button
+                type="button"
+                className={styles.iconButton}
                 onClick={() => deleteInjectable(idx)}
                 aria-label="Delete injectable"
               >
@@ -224,7 +241,11 @@ function Config() {
             </div>
           </div>
         ))}
-        <button type="button" className={styles.addButton} onClick={addInjectable}>
+        <button
+          type="button"
+          className={styles.addButton}
+          onClick={addInjectable}
+        >
           Add another
         </button>
 
@@ -258,6 +279,16 @@ function Config() {
                 aria-label={oral.disabled ? 'Enable oral' : 'Disable oral'}
               >
                 <GiSightDisabled size={20} />
+              </button>
+              <button
+                type="button"
+                className={styles.iconButton}
+                onClick={() => openWikipedia(oral.name)}
+                aria-label={`Search Wikipedia for ${oral.name}`}
+                title={`Search Wikipedia for ${oral.name}`}
+                disabled={!oral.name.trim()}
+              >
+                <FiInfo size={20} />
               </button>
               <button
                 type="button"

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-const version = '0.0.0022';
+const version = '0.0.0024';
 export default version;


### PR DESCRIPTION
## Summary
- add FiInfo icon for wiki searches
- open new tab with encoded URL using openWikipedia helper
- disable button when input empty and style disabled buttons
- bump version to 0.0.0024
- document changes in README and CHANGELOG

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6861c7a5159083318e089363d6716d5c