### PR TITLE
Implement calendar-based injection schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@
 - 2025-06-29 22:49 · Add Oral Schedule page and conditional sidebar visibility based on enabled medications · v0.0.0020
 - 2025-06-29 22:56 · Unspecified task · v0.0.0021
 - 2025-06-29 22:59 · Conditionally display schedule pages in sidebar based on enabled medication entries · v0.0.0022
+- 2025-06-29 23:33 · Unspecified task · v0.0.0023

--- a/README.md
+++ b/README.md
@@ -42,3 +42,4 @@ The application will display `Welcome to TRT Planner` and persist state across r
 - 2025-06-29 22:49 · Add Oral Schedule page and conditional sidebar visibility based on enabled medications · v0.0.0020
 - 2025-06-29 22:56 · Unspecified task · v0.0.0021
 - 2025-06-29 22:59 · Conditionally display schedule pages in sidebar based on enabled medication entries · v0.0.0022
+- 2025-06-29 23:33 · Unspecified task · v0.0.0023

--- a/src/pages/InjectionSchedule.module.css
+++ b/src/pages/InjectionSchedule.module.css
@@ -200,3 +200,81 @@
 .deleteButton:hover {
   background: #b91c1c;
 }
+
+/* Calendar styles */
+.calendar {
+  margin-top: 1rem;
+}
+
+.calendarNav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
+.navButton {
+  background: #e2e8f0;
+  color: #1e293b;
+  border: none;
+  border-radius: 0.375rem;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.navButton:hover {
+  background: #cbd5e1;
+}
+
+.months {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.month {
+  width: 260px;
+}
+
+.monthName {
+  text-align: center;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.weekdays,
+.days {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  text-align: center;
+}
+
+.weekday {
+  font-size: 0.75rem;
+  color: #64748b;
+}
+
+.day {
+  padding: 0.25rem;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.day:hover {
+  background: #e2e8f0;
+}
+
+.today {
+  background: #f1f5f9;
+  font-weight: 600;
+}
+
+.selected {
+  background: #cbd5e1;
+}
+
+.otherMonth {
+  color: #94a3b8;
+}

--- a/src/pages/InjectionSchedule.tsx
+++ b/src/pages/InjectionSchedule.tsx
@@ -1,136 +1,198 @@
 import { useEffect, useState } from 'react';
-import { GiSightDisabled } from 'react-icons/gi';
-import { FaRegTrashAlt } from 'react-icons/fa';
 import styles from './InjectionSchedule.module.css';
 
-interface ScheduleEntry {
-  medication: string;
-  date: string;
+interface Medication {
+  name: string;
   disabled?: boolean;
 }
 
+interface CalendarState {
+  [medication: string]: string[];
+}
+
+const startOfMonth = (date: Date) => new Date(date.getFullYear(), date.getMonth(), 1);
+
+const addMonths = (date: Date, amount: number) => {
+  const d = new Date(date);
+  d.setMonth(d.getMonth() + amount);
+  return d;
+};
+
+const isSameDay = (a: Date, b: Date) => a.toDateString() === b.toDateString();
+
+const generateCalendar = (year: number, month: number) => {
+  const first = new Date(year, month, 1);
+  const start = new Date(first);
+  start.setDate(first.getDate() - first.getDay());
+
+  const weeks: Date[][] = [];
+  let current = start;
+  for (let w = 0; w < 6; w += 1) {
+    const week: Date[] = [];
+    for (let d = 0; d < 7; d += 1) {
+      week.push(new Date(current));
+      current = new Date(current);
+      current.setDate(current.getDate() + 1);
+    }
+    weeks.push(week);
+  }
+  return weeks;
+};
+
+type CalendarProps = {
+  selected: string[];
+  onToggleDate: (date: string) => void;
+};
+
+function Calendar({ selected, onToggleDate }: CalendarProps) {
+  const [monthOffset, setMonthOffset] = useState(0);
+  const today = new Date();
+  const firstMonth = startOfMonth(addMonths(today, monthOffset));
+  const secondMonth = addMonths(firstMonth, 1);
+  const selectedSet = new Set(selected);
+
+  const renderMonth = (date: Date) => {
+    const weeks = generateCalendar(date.getFullYear(), date.getMonth());
+    const monthName = date.toLocaleString(undefined, {
+      month: 'long',
+      year: 'numeric',
+    });
+
+    return (
+      <div className={styles.month}>
+        <div className={styles.monthName}>{monthName}</div>
+        <div className={styles.weekdays}>
+          {['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].map((d) => (
+            <div key={d} className={styles.weekday}>
+              {d}
+            </div>
+          ))}
+        </div>
+        <div className={styles.days}>
+          {weeks.flat().map((day) => {
+            const inMonth = day.getMonth() === date.getMonth();
+            const dayStr = day.toISOString().split('T')[0];
+            const classes = [styles.day];
+            if (!inMonth) classes.push(styles.otherMonth);
+            if (isSameDay(day, today)) classes.push(styles.today);
+            if (selectedSet.has(dayStr)) classes.push(styles.selected);
+            return (
+              <div
+                key={dayStr}
+                className={classes.join(' ')}
+                role="button"
+                tabIndex={0}
+                onClick={() => onToggleDate(dayStr)}
+                onKeyDown={(e) => e.key === 'Enter' && onToggleDate(dayStr)}
+              >
+                {day.getDate()}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className={styles.calendar}>
+      <div className={styles.calendarNav}>
+        <button
+          type="button"
+          className={styles.navButton}
+          onClick={() => setMonthOffset((m) => m - 1)}
+        >
+          ‹
+        </button>
+        <button
+          type="button"
+          className={styles.navButton}
+          onClick={() => setMonthOffset((m) => m + 1)}
+        >
+          ›
+        </button>
+      </div>
+      <div className={styles.months}>{[firstMonth, secondMonth].map(renderMonth)}</div>
+    </div>
+  );
+}
+
 function InjectionSchedule() {
-  const [entries, setEntries] = useState<ScheduleEntry[]>([]);
-  const [saved, setSaved] = useState(false);
+  const [medications, setMedications] = useState<Medication[]>([]);
+  const [calendar, setCalendar] = useState<CalendarState>({});
 
   useEffect(() => {
-    const stored = localStorage.getItem('injectionSchedule');
-    if (stored) {
-      try {
-        const parsed = JSON.parse(stored);
-        if (Array.isArray(parsed)) {
-          setEntries(
-            parsed.map((e: ScheduleEntry) => ({
-              medication: e.medication ?? '',
-              date: e.date ?? '',
-              disabled: e.disabled ?? false,
-            })),
+    try {
+      const cfgRaw = localStorage.getItem('configSettings');
+      if (cfgRaw) {
+        const cfg = JSON.parse(cfgRaw);
+        if (Array.isArray(cfg.injectables)) {
+          setMedications(
+            cfg.injectables.filter(
+              (i: Medication) => i.name && !i.disabled,
+            ),
           );
         }
-      } catch (err) {
-        // eslint-disable-next-line no-console
-        console.error('Failed to parse schedule', err);
       }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to load config', err);
     }
   }, []);
 
-  const handleMedicationChange = (idx: number, value: string) => {
-    const updated = [...entries];
-    updated[idx].medication = value;
-    setEntries(updated);
-  };
-
-  const handleDateChange = (idx: number, value: string) => {
-    const updated = [...entries];
-    updated[idx].date = value;
-    setEntries(updated);
-  };
-
-  const addEntry = () => {
-    setEntries([...entries, { medication: '', date: '', disabled: false }]);
-  };
-
-  const toggleDisable = (idx: number) => {
-    const updated = [...entries];
-    updated[idx].disabled = !updated[idx].disabled;
-    setEntries(updated);
-  };
-
-  const deleteEntry = (idx: number) => {
-    // eslint-disable-next-line no-alert
-    if (window.confirm('Are you sure you want to delete this entry?')) {
-      setEntries((prev) => {
-        const updated = [...prev];
-        updated.splice(idx, 1);
-        return updated;
-      });
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem('injectionCalendar');
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        if (parsed && typeof parsed === 'object') {
+          setCalendar(parsed);
+        }
+      }
+    } catch {
+      // ignore
     }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('injectionCalendar', JSON.stringify(calendar));
+  }, [calendar]);
+
+  const toggleDate = (med: string, date: string) => {
+    setCalendar((prev) => {
+      const current = new Set(prev[med] || []);
+      if (current.has(date)) {
+        current.delete(date);
+      } else {
+        current.add(date);
+      }
+      return { ...prev, [med]: Array.from(current).sort() };
+    });
   };
 
-  const handleSave = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    localStorage.setItem('injectionSchedule', JSON.stringify(entries));
-    setSaved(true);
-    setTimeout(() => setSaved(false), 2000);
-  };
+  if (medications.length === 0) {
+    return (
+      <>
+        <h1 className={styles.pageTitle}>Injection Schedule</h1>
+        <div className={styles.container}>
+          <p>No injectable medications enabled. Configure them first.</p>
+        </div>
+      </>
+    );
+  }
 
   return (
     <>
       <h1 className={styles.pageTitle}>Injection Schedule</h1>
-      <form className={styles.container} onSubmit={handleSave}>
-        {entries.map((entry, idx) => (
-          <div
-            key={idx} // eslint-disable-line react/no-array-index-key
-            className={styles.injectableRow}
-          >
-            <span className={styles.rowIndex}>{`${idx + 1}.`}</span>
-            <input
-              type="text"
-              placeholder="Medication"
-              className={`${styles.input} ${styles.injectableInput} ${
-                entry.disabled ? styles.disabledInput : ''
-              }`}
-              value={entry.medication}
-              disabled={entry.disabled}
-              onChange={(e) => handleMedicationChange(idx, e.target.value)}
-            />
-            <input
-              type="date"
-              className={`${styles.input} ${styles.injectableInput} ${
-                entry.disabled ? styles.disabledInput : ''
-              }`}
-              value={entry.date}
-              disabled={entry.disabled}
-              onChange={(e) => handleDateChange(idx, e.target.value)}
-            />
-            <div className={styles.injectableActions}>
-              <button
-                type="button"
-                className={styles.iconButton}
-                onClick={() => toggleDisable(idx)}
-                aria-label={entry.disabled ? 'Enable entry' : 'Disable entry'}
-              >
-                <GiSightDisabled size={20} />
-              </button>
-              <button
-                type="button"
-                className={styles.iconButton}
-                onClick={() => deleteEntry(idx)}
-                aria-label="Delete entry"
-              >
-                <FaRegTrashAlt size={20} />
-              </button>
-            </div>
-          </div>
-        ))}
-        <button type="button" className={styles.addButton} onClick={addEntry}>
-          Add another
-        </button>
-        <button type="submit" className={styles.saveButton}>
-          Save
-        </button>
-        {saved && <div className={styles.savedMessage}>Schedule saved!</div>}
-      </form>
+      {medications.map((med) => (
+        <div key={med.name} className={styles.container}>
+          <h2 className={styles.sectionTitle}>{med.name}</h2>
+          <Calendar
+            selected={calendar[med.name] || []}
+            onToggleDate={(d) => toggleDate(med.name, d)}
+          />
+        </div>
+      ))}
     </>
   );
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-const version = '0.0.0022';
+const version = '0.0.0023';
 export default version;


### PR DESCRIPTION
## Summary
- redesign Injection Schedule page
- load enabled injectables from localStorage
- render a custom calendar for each medication
- persist injection dates per medication

## Testing
- `npm run lint --silent`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6861cd203ab48331abf39bf2b830a4da