### PR TITLE
Display calendar on injection schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,5 @@
 - 2025-06-29 22:49 · Add Oral Schedule page and conditional sidebar visibility based on enabled medications · v0.0.0020
 - 2025-06-29 22:56 · Unspecified task · v0.0.0021
 - 2025-06-29 22:59 · Conditionally display schedule pages in sidebar based on enabled medication entries · v0.0.0022
+- 2025-06-29 23:34 · Unspecified task · v0.0.0023
+- 2025-06-29 23:45 · Display a calendar for each enabled injectable medication · v0.0.0024

--- a/README.md
+++ b/README.md
@@ -42,3 +42,5 @@ The application will display `Welcome to TRT Planner` and persist state across r
 - 2025-06-29 22:49 · Add Oral Schedule page and conditional sidebar visibility based on enabled medications · v0.0.0020
 - 2025-06-29 22:56 · Unspecified task · v0.0.0021
 - 2025-06-29 22:59 · Conditionally display schedule pages in sidebar based on enabled medication entries · v0.0.0022
+- 2025-06-29 23:34 · Unspecified task · v0.0.0023
+- 2025-06-29 23:45 · Display a calendar for each enabled injectable medication · v0.0.0024

--- a/src/pages/InjectionSchedule.module.css
+++ b/src/pages/InjectionSchedule.module.css
@@ -200,3 +200,65 @@
 .deleteButton:hover {
   background: #b91c1c;
 }
+.medSection {
+  margin-bottom: 2rem;
+}
+
+.calendarNav {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
+.calendarWrapper {
+  display: flex;
+  gap: 1rem;
+  overflow-x: auto;
+}
+
+.calendar {
+  background: #ffffff;
+  border-radius: 0.5rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  padding: 0.5rem;
+  min-width: 280px;
+}
+
+.calendarHeader {
+  text-align: center;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.dayHeaders,
+.grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 0.25rem;
+}
+
+.dayHeader {
+  text-align: center;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #64748b;
+}
+
+.day {
+  text-align: center;
+  padding: 0.25rem 0;
+}
+
+.today {
+  background: #e2e8f0;
+  border-radius: 0.25rem;
+}
+
+.empty {
+  visibility: hidden;
+}
+
+.emptyState {
+  text-align: center;
+  color: #64748b;
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-const version = '0.0.0022';
+const version = '0.0.0024';
 export default version;


### PR DESCRIPTION
## Summary
- show injectable calendars pulled from configuration
- allow paging through months and highlight today
- update changelog and README
- bump version to v0.0.0024

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6861cd203ab48331abf39bf2b830a4da