### PR TITLE
Improve medication calendar layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,5 @@
 - 2025-06-29 22:59 · Conditionally display schedule pages in sidebar based on enabled medication entries · v0.0.0022
 - 2025-06-29 23:34 · Unspecified task · v0.0.0023
 - 2025-06-29 23:37 · Display a calendar for each enabled injectable medication · v0.0.0024
+- 2025-06-29 23:52 · Unspecified task · v0.0.0025
+- 2025-06-29 23:54 · Improve visual separation between medication calendar blocks on Injection Schedule page · v0.0.0026

--- a/README.md
+++ b/README.md
@@ -44,3 +44,5 @@ The application will display `Welcome to TRT Planner` and persist state across r
 - 2025-06-29 22:59 · Conditionally display schedule pages in sidebar based on enabled medication entries · v0.0.0022
 - 2025-06-29 23:34 · Unspecified task · v0.0.0023
 - 2025-06-29 23:37 · Display a calendar for each enabled injectable medication · v0.0.0024
+- 2025-06-29 23:52 · Unspecified task · v0.0.0025
+- 2025-06-29 23:54 · Improve visual separation between medication calendar blocks on Injection Schedule page · v0.0.0026

--- a/src/pages/InjectionSchedule.module.css
+++ b/src/pages/InjectionSchedule.module.css
@@ -204,6 +204,14 @@
   margin-bottom: 2rem;
 }
 
+.medicationSection {
+  margin-bottom: 2rem;
+  padding: 1rem;
+  background: #ffffff;
+  border-radius: 0.75rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
 .calendar {
   width: 100%;
   border: 1px solid #e5e7eb;

--- a/src/pages/InjectionSchedule.tsx
+++ b/src/pages/InjectionSchedule.tsx
@@ -63,7 +63,10 @@ function InjectionSchedule() {
         </p>
       ) : (
         meds.map((m) => (
-          <section key={m.name} className={styles.calendarSection}>
+          <section
+            key={m.name}
+            className={`${styles.calendarSection} ${styles.medicationSection}`}
+          >
             <h2 className={styles.sectionTitle}>{m.name}</h2>
             <Calendar
               showDoubleView

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-const version = '0.0.0024';
+const version = '0.0.0026';
 export default version;


### PR DESCRIPTION
## Summary
- tweak InjectionSchedule style to better separate medication blocks
- update InjectionSchedule calendars to use the new style container
- bump version to 0.0.0026
- document changes in CHANGELOG and README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6861d179b6588331b0e49f03cd093bc8