### PR TITLE
feat: responsive calendar view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,6 @@
 - 2025-06-29 23:37 · Display a calendar for each enabled injectable medication · v0.0.0024
 - 2025-06-29 23:52 · Unspecified task · v0.0.0025
 - 2025-06-29 23:54 · Improve visual separation between medication calendar blocks on Injection Schedule page · v0.0.0026
+- 2025-06-30 00:16 · Unspecified task · v0.0.0027
+
+- 2025-06-30 00:18 · Make calendar view responsive: 2 months on desktop, 1 month on mobile · v0.0.0028

--- a/README.md
+++ b/README.md
@@ -46,3 +46,6 @@ The application will display `Welcome to TRT Planner` and persist state across r
 - 2025-06-29 23:37 · Display a calendar for each enabled injectable medication · v0.0.0024
 - 2025-06-29 23:52 · Unspecified task · v0.0.0025
 - 2025-06-29 23:54 · Improve visual separation between medication calendar blocks on Injection Schedule page · v0.0.0026
+- 2025-06-30 00:16 · Unspecified task · v0.0.0027
+
+- 2025-06-30 00:18 · Make calendar view responsive: 2 months on desktop, 1 month on mobile · v0.0.0028

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+function useIsMobile(breakpoint = 768): boolean {
+  const [isMobile, setIsMobile] = useState(
+    typeof window !== 'undefined' ? window.innerWidth < breakpoint : false,
+  );
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth < breakpoint);
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [breakpoint]);
+
+  return isMobile;
+}
+
+export default useIsMobile;

--- a/src/pages/InjectionSchedule.tsx
+++ b/src/pages/InjectionSchedule.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import Calendar from 'react-calendar';
+import useIsMobile from '../hooks/useIsMobile';
 import 'react-calendar/dist/Calendar.css';
 import styles from './InjectionSchedule.module.css';
 
@@ -20,6 +21,7 @@ const sameDay = (a: Date, b: Date) =>
 function InjectionSchedule() {
   const [meds, setMeds] = useState<Medication[]>([]);
   const [dates, setDates] = useState<Selections>({});
+  const isMobile = useIsMobile();
 
   useEffect(() => {
     try {
@@ -69,7 +71,7 @@ function InjectionSchedule() {
           >
             <h2 className={styles.sectionTitle}>{m.name}</h2>
             <Calendar
-              showDoubleView
+              showDoubleView={!isMobile}
               prev2Label={null}
               next2Label={null}
               onClickDay={(d) => toggleDate(m.name, d)}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-const version = '0.0.0026';
+const version = '0.0.0028';
 export default version;


### PR DESCRIPTION
## Summary
- add useIsMobile hook for responsive checks
- show two-month or one-month calendar based on screen size
- bump version to v0.0.0028
- log change in README and CHANGELOG

## Testing
- `npm run lint`
- `npm run format`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6861d735c54c83319db9aa029904c170