### PR TITLE
Add configurable injection schedules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,5 @@
 - 2025-06-30 00:16 · Unspecified task · v0.0.0027
 
 - 2025-06-30 00:18 · Make calendar view responsive: 2 months on desktop, 1 month on mobile · v0.0.0028
+- 2025-06-30 00:25 · Unspecified task · v0.0.0029
+- 2025-06-30 00:28 · Add configurable injection frequency logic with apply/reset controls for each medication section · v0.0.0030

--- a/README.md
+++ b/README.md
@@ -49,3 +49,5 @@ The application will display `Welcome to TRT Planner` and persist state across r
 - 2025-06-30 00:16 · Unspecified task · v0.0.0027
 
 - 2025-06-30 00:18 · Make calendar view responsive: 2 months on desktop, 1 month on mobile · v0.0.0028
+- 2025-06-30 00:25 · Unspecified task · v0.0.0029
+- 2025-06-30 00:28 · Add configurable injection frequency logic with apply/reset controls for each medication section · v0.0.0030

--- a/src/pages/InjectionSchedule.module.css
+++ b/src/pages/InjectionSchedule.module.css
@@ -219,9 +219,54 @@
   padding: 0.5rem;
 }
 
-.selectedDay {
-  background: #1e293b !important;
-  color: #ffffff !important;
+.scheduledDay {
+  background: #4ade80 !important;
+  border: 1px solid #22c55e !important;
+  color: #1e293b !important;
+}
+
+.configSection {
+  margin-bottom: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.daysOfWeek {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.dayToggle {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.buttonRow {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.applyButton {
+  background: #1e293b;
+  color: #ffffff;
+  border: none;
+  border-radius: 0.5rem;
+  padding: 0.5rem 1rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.resetButton {
+  background: #f1f5f9;
+  color: #1e293b;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.5rem;
+  padding: 0.5rem 1rem;
+  font-weight: 500;
+  cursor: pointer;
 }
 
 .emptyState {

--- a/src/pages/InjectionSchedule.tsx
+++ b/src/pages/InjectionSchedule.tsx
@@ -9,18 +9,22 @@ interface Medication {
   disabled?: boolean;
 }
 
-interface Selections {
-  [name: string]: Date[];
+type Frequency = 'daily' | 'everyOther' | 'specific';
+
+interface ScheduleConfig {
+  frequency: Frequency;
+  anchor?: string; // ISO date string
+  daysOfWeek?: number[];
 }
 
-const sameDay = (a: Date, b: Date) =>
-  a.getFullYear() === b.getFullYear() &&
-  a.getMonth() === b.getMonth() &&
-  a.getDate() === b.getDate();
+interface ScheduleMap {
+  [name: string]: ScheduleConfig;
+}
 
 function InjectionSchedule() {
   const [meds, setMeds] = useState<Medication[]>([]);
-  const [dates, setDates] = useState<Selections>({});
+  const [configs, setConfigs] = useState<ScheduleMap>({});
+  const [editing, setEditing] = useState<ScheduleMap>({});
   const isMobile = useIsMobile();
 
   useEffect(() => {
@@ -30,28 +34,95 @@ function InjectionSchedule() {
       const injectables: Medication[] = Array.isArray(cfg.injectables)
         ? cfg.injectables
         : JSON.parse(localStorage.getItem('injectables') || '[]');
-      setMeds(injectables.filter((m) => m.name && !m.disabled));
+      const active = injectables.filter((m) => m.name && !m.disabled);
+      setMeds(active);
+
+      const stored = localStorage.getItem('injectionSchedule');
+      const parsed: ScheduleMap = stored ? JSON.parse(stored) : {};
+      setConfigs(parsed);
+      const edit: ScheduleMap = {};
+      active.forEach((m) => {
+        edit[m.name] =
+          parsed[m.name] || { frequency: 'daily', daysOfWeek: [], anchor: undefined };
+      });
+      setEditing(edit);
     } catch {
       setMeds([]);
+      setConfigs({});
+      setEditing({});
     }
   }, []);
 
-  const toggleDate = (name: string, date: Date) => {
-    setDates((prev) => {
-      const arr = prev[name] || [];
-      const exists = arr.some((d) => sameDay(d, date));
-      const updated = exists
-        ? arr.filter((d) => !sameDay(d, date))
-        : [...arr, date];
-      return { ...prev, [name]: updated };
+  const handleFreqChange = (name: string, freq: Frequency) => {
+    setEditing((prev) => ({
+      ...prev,
+      [name]: { ...prev[name], frequency: freq },
+    }));
+  };
+
+  const toggleDayOfWeek = (name: string, day: number) => {
+    setEditing((prev) => {
+      const days = prev[name].daysOfWeek || [];
+      const updated = days.includes(day)
+        ? days.filter((d) => d !== day)
+        : [...days, day];
+      return { ...prev, [name]: { ...prev[name], daysOfWeek: updated } };
+    });
+  };
+
+  const applyConfig = (name: string) => {
+    setConfigs((prev) => {
+      const updated = { ...prev, [name]: editing[name] };
+      localStorage.setItem('injectionSchedule', JSON.stringify(updated));
+      return updated;
+    });
+  };
+
+  const resetConfig = (name: string) => {
+    setConfigs((prev) => {
+      const updated = { ...prev };
+      delete updated[name];
+      localStorage.setItem('injectionSchedule', JSON.stringify(updated));
+      return updated;
+    });
+    setEditing((prev) => ({
+      ...prev,
+      [name]: { frequency: 'daily', daysOfWeek: [], anchor: undefined },
+    }));
+  };
+
+  const handleAnchorSelect = (name: string, date: Date) => {
+    setEditing((prev) => ({
+      ...prev,
+      [name]: { ...prev[name], anchor: date.toISOString() },
+    }));
+    setConfigs((prev) => {
+      const updated = {
+        ...prev,
+        [name]: { ...prev[name], anchor: date.toISOString(), frequency: 'everyOther' },
+      };
+      localStorage.setItem('injectionSchedule', JSON.stringify(updated));
+      return updated;
     });
   };
 
   const tileClassName =
     (name: string) =>
     ({ date, view }: { date: Date; view: string }) => {
-      if (view === 'month' && dates[name]?.some((d) => sameDay(d, date))) {
-        return styles.selectedDay;
+      if (view !== 'month') return undefined;
+      const cfg = configs[name];
+      if (!cfg) return undefined;
+      if (cfg.frequency === 'daily') return styles.scheduledDay;
+      if (cfg.frequency === 'everyOther' && cfg.anchor) {
+        const diff = Math.round(
+          (date.getTime() - new Date(cfg.anchor).getTime()) / 86400000,
+        );
+        return diff % 2 === 0 ? styles.scheduledDay : undefined;
+      }
+      if (cfg.frequency === 'specific' && cfg.daysOfWeek?.length) {
+        return cfg.daysOfWeek.includes(date.getDay())
+          ? styles.scheduledDay
+          : undefined;
       }
       return undefined;
     };
@@ -70,11 +141,62 @@ function InjectionSchedule() {
             className={`${styles.calendarSection} ${styles.medicationSection}`}
           >
             <h2 className={styles.sectionTitle}>{m.name}</h2>
+            <div className={styles.configSection}>
+              <label htmlFor={`freq-${m.name}`} className={styles.label}>
+                Frequency
+                <select
+                  id={`freq-${m.name}`}
+                  className={styles.select}
+                  value={editing[m.name]?.frequency}
+                  onChange={(e) =>
+                    handleFreqChange(m.name, e.target.value as Frequency)
+                  }
+                >
+                  <option value="daily">Every day</option>
+                  <option value="everyOther">Every other day</option>
+                  <option value="specific">Specific days of the week</option>
+                </select>
+              </label>
+              {editing[m.name]?.frequency === 'specific' && (
+                <div className={styles.daysOfWeek}>
+                  {[0, 1, 2, 3, 4, 5, 6].map((d) => (
+                    <div key={d} className={styles.dayToggle}>
+                      <input
+                        id={`day-${m.name}-${d}`}
+                        type="checkbox"
+                        checked={editing[m.name]?.daysOfWeek?.includes(d) || false}
+                        onChange={() => toggleDayOfWeek(m.name, d)}
+                      />
+                      <label htmlFor={`day-${m.name}-${d}`}>{['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][d]}</label>
+                    </div>
+                  ))}
+                </div>
+              )}
+              <div className={styles.buttonRow}>
+                <button
+                  type="button"
+                  className={styles.applyButton}
+                  onClick={() => applyConfig(m.name)}
+                >
+                  Apply
+                </button>
+                <button
+                  type="button"
+                  className={styles.resetButton}
+                  onClick={() => resetConfig(m.name)}
+                >
+                  Reset
+                </button>
+              </div>
+            </div>
             <Calendar
               showDoubleView={!isMobile}
               prev2Label={null}
               next2Label={null}
-              onClickDay={(d) => toggleDate(m.name, d)}
+              onClickDay={(d) =>
+                editing[m.name]?.frequency === 'everyOther' &&
+                handleAnchorSelect(m.name, d)
+              }
               tileClassName={tileClassName(m.name)}
               className={styles.calendar}
             />

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-const version = '0.0.0028';
+const version = '0.0.0030';
 export default version;


### PR DESCRIPTION
## Summary
- add per-medication frequency configs and save to localStorage
- show frequency select box, weekday toggles and apply/reset buttons
- highlight scheduled days in green
- bump version to 0.0.0030
- document changes in CHANGELOG and README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6861d927308883318fb4591cc113c261