### PR TITLE
Fix runtime errors in InjectionSchedule and share modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,5 @@
 - 2025-06-30 01:04 · End of Day 1 milestone · v0.1.0000
 - 2025-06-30 14:43 · Unspecified task · v0.1.0001
 - 2025-06-30 14:48 · Refactor injection schedule view to use horizontal drug tab navigation · v0.1.0002
+- 2025-06-30 19:35 · Unspecified task · v0.1.0003
+- 2025-06-30 19:39 · Fix broken import and DOM event listener error to restore live preview rendering · v0.1.0004

--- a/README.md
+++ b/README.md
@@ -114,3 +114,5 @@ The TRT Planner team
 - 2025-06-30 01:04 · End of Day 1 milestone · v0.1.0000
 - 2025-06-30 14:43 · Unspecified task · v0.1.0001
 - 2025-06-30 14:48 · Refactor injection schedule view to use horizontal drug tab navigation · v0.1.0002
+- 2025-06-30 19:35 · Unspecified task · v0.1.0003
+- 2025-06-30 19:39 · Fix broken import and DOM event listener error to restore live preview rendering · v0.1.0004

--- a/public/share-modal.js
+++ b/public/share-modal.js
@@ -1,0 +1,9 @@
+const el = document.getElementById('share-button');
+if (el) {
+  el.addEventListener('click', () => {
+    const modal = document.getElementById('share-modal');
+    if (modal) {
+      modal.classList.add('open');
+    }
+  });
+}

--- a/src/pages/InjectionSchedule.tsx
+++ b/src/pages/InjectionSchedule.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
 import useIsMobile from '../hooks/useIsMobile';
 import 'react-calendar/dist/Calendar.css';
-import DrugSchedule, { Frequency, ScheduleConfig } from './DrugSchedule';
+import DrugSchedule from './DrugSchedule';
+import type { Frequency, ScheduleConfig } from './DrugSchedule';
 import styles from './InjectionSchedule.module.css';
 
 interface Medication {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-const version = '0.1.0002';
+const version = '0.1.0004';
 export default version;


### PR DESCRIPTION
## Summary
- fix incorrect import for `Frequency` type
- add null check around share button event listener
- bump version to 0.1.0004
- update changelog and README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6862e6c71a688331ae10c7d524c71a42