### PR TITLE
Rename TRT Planner to MediTrack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,5 @@
 - 2025-06-30 14:48 · Refactor injection schedule view to use horizontal drug tab navigation · v0.1.0002
 - 2025-06-30 19:35 · Unspecified task · v0.1.0003
 - 2025-06-30 19:39 · Fix broken import and DOM event listener error to restore live preview rendering · v0.1.0004
+- 2025-06-30 19:50 · Unspecified task · v0.1.0005
+- 2025-06-30 19:52 · Rename application from TRT Planner to MediTrack · v0.1.0006

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# TRT Planner
+# MediTrack
 
 ## Overview
 
-TRT Planner is a self‑hosted medical tracking app built with **React** and **TypeScript** using Vite. It stores all data locally in the browser and requires no backend services. The app lets you configure medications and plan upcoming doses through interactive calendars.
+MediTrack is a self‑hosted medical tracking app built with **React** and **TypeScript** using Vite. It stores all data locally in the browser and requires no backend services. The app lets you configure medications and plan upcoming doses through interactive calendars.
 
 ## Tech Stack
 
@@ -72,11 +72,11 @@ The current version is tracked in `src/version.ts`. Each commit bumps the patch 
 
 ## Privacy
 
-TRT Planner does not send data anywhere. All configuration and schedules are stored in the browser via `localStorage`.
+MediTrack does not send data anywhere. All configuration and schedules are stored in the browser via `localStorage`.
 
 ## Author
 
-The TRT Planner team
+The MediTrack team
 
 ## Changelog
 
@@ -116,3 +116,5 @@ The TRT Planner team
 - 2025-06-30 14:48 · Refactor injection schedule view to use horizontal drug tab navigation · v0.1.0002
 - 2025-06-30 19:35 · Unspecified task · v0.1.0003
 - 2025-06-30 19:39 · Fix broken import and DOM event listener error to restore live preview rendering · v0.1.0004
+- 2025-06-30 19:50 · Unspecified task · v0.1.0005
+- 2025-06-30 19:52 · Rename application from TRT Planner to MediTrack · v0.1.0006

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>MediTrack</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "trtplanner",
+  "name": "meditrack",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "trtplanner",
+      "name": "meditrack",
       "version": "0.0.0",
       "dependencies": {
         "@reduxjs/toolkit": "^2.8.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "trtplanner",
+  "name": "meditrack",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -80,7 +80,7 @@ function Sidebar() {
             <div className={styles.logoWrapper}>
               <img src={logo} alt="logo" className={styles.logo} />
             </div>
-            <h2 className={styles.title}>TRT Planner</h2>
+            <h2 className={styles.title}>MediTrack</h2>
           </div>
           <nav className={styles.nav}>
             <NavLink

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,8 +5,8 @@ function Home() {
   return (
     <div className={styles.home}>
       <div className={styles.card}>
-        <img src={logo} alt="TRT Planner Logo" className={styles.logo} />
-        <h1 className={styles.title}>TRT Planner</h1>
+        <img src={logo} alt="MediTrack Logo" className={styles.logo} />
+        <h1 className={styles.title}>MediTrack</h1>
       </div>
     </div>
   );

--- a/src/slices/appSlice.ts
+++ b/src/slices/appSlice.ts
@@ -6,7 +6,7 @@ interface AppState {
 }
 
 const initialState: AppState = {
-  message: 'Welcome to TRT Planner',
+  message: 'Welcome to MediTrack',
 };
 
 const appSlice = createSlice({

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-const version = '0.1.0004';
+const version = '0.1.0006';
 export default version;


### PR DESCRIPTION
## Summary
- rename all UI and internal references from TRT Planner to MediTrack
- bump version to 0.1.0006
- log the rename in CHANGELOG and README
- update package metadata and HTML title

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6862ea3be5a48331a85fecf52d0e52b7