### PR TITLE
Enhance MediTrack sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,3 +41,5 @@
 - 2025-06-30 19:52 · Rename application from TRT Planner to MediTrack · v0.1.0006
 - 2025-06-30 20:19 · Unspecified task · v0.1.0007
 - 2025-06-30 20:24 · Rebrand app with MediTrack logo and updated light theme · v0.1.0008
+- 2025-06-30 20:37 · Unspecified task · v0.1.0009
+- 2025-06-30 20:39 · Improve MediTrack sidebar styling and add click-outside close behavior · v0.1.0010

--- a/README.md
+++ b/README.md
@@ -120,3 +120,5 @@ The MediTrack team
 - 2025-06-30 19:52 · Rename application from TRT Planner to MediTrack · v0.1.0006
 - 2025-06-30 20:19 · Unspecified task · v0.1.0007
 - 2025-06-30 20:24 · Rebrand app with MediTrack logo and updated light theme · v0.1.0008
+- 2025-06-30 20:37 · Unspecified task · v0.1.0009
+- 2025-06-30 20:39 · Improve MediTrack sidebar styling and add click-outside close behavior · v0.1.0010

--- a/src/hooks/useOutsideClick.ts
+++ b/src/hooks/useOutsideClick.ts
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+
+function useOutsideClick(
+  isActive: boolean,
+  ref: React.RefObject<HTMLElement>,
+  exclude: React.RefObject<HTMLElement> | null,
+  handler: () => void,
+) {
+  useEffect(() => {
+    function handle(e: MouseEvent | TouchEvent) {
+      const target = e.target as Node;
+      if (
+        isActive &&
+        ref.current &&
+        !ref.current.contains(target) &&
+        (!exclude || !exclude.current || !exclude.current.contains(target))
+      ) {
+        handler();
+      }
+    }
+    document.addEventListener('mousedown', handle);
+    document.addEventListener('touchstart', handle);
+    return () => {
+      document.removeEventListener('mousedown', handle);
+      document.removeEventListener('touchstart', handle);
+    };
+  }, [isActive, ref, exclude, handler]);
+}
+
+export default useOutsideClick;

--- a/src/layout/Sidebar.module.css
+++ b/src/layout/Sidebar.module.css
@@ -4,7 +4,12 @@
   left: 0;
   width: 250px;
   height: 100vh;
-  background: linear-gradient(180deg, var(--accent-primary), #059669);
+  background: linear-gradient(
+    180deg,
+    #ecfdf5 0%,
+    var(--accent-primary) 40%,
+    #059669 100%
+  );
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
   padding: 1rem;
   display: flex;
@@ -25,8 +30,10 @@
   align-items: center;
   gap: 0.75rem;
   margin-bottom: 1.5rem;
-  padding-bottom: 1rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 0.75rem 1rem;
+  background: #ffffff;
+  border-radius: 6px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
 }
 
 .title {

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { NavLink } from 'react-router-dom';
 import { FaHome, FaSyringe, FaPlane, FaCog } from 'react-icons/fa';
 import { GiMedicines } from 'react-icons/gi';
@@ -6,11 +6,14 @@ import { MdMenu, MdClose } from 'react-icons/md';
 import version from '../version';
 import logo from '../assets/meditrack-logo-horizontal.png';
 import styles from './Sidebar.module.css';
+import useOutsideClick from '../hooks/useOutsideClick';
 
 function Sidebar() {
   const [open, setOpen] = useState(false);
   const [hasInjectables, setHasInjectables] = useState(false);
   const [hasOrals, setHasOrals] = useState(false);
+  const sidebarRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
 
   const checkMedications = () => {
     try {
@@ -60,11 +63,14 @@ function Sidebar() {
   const linkClass = ({ isActive }: { isActive: boolean }) =>
     `${styles.link} ${isActive ? styles.active : ''}`;
 
+  useOutsideClick(open, sidebarRef, buttonRef, () => setOpen(false));
+
   return (
     <>
       <button
         type="button"
         onClick={toggle}
+        ref={buttonRef}
         className={`${styles.toggleButton} ${open ? styles.buttonOpen : ''}`}
       >
         {open ? (
@@ -76,7 +82,10 @@ function Sidebar() {
           <MdMenu className={styles.icon} color="white" />
         )}
       </button>
-      <aside className={`${styles.sidebar} ${!open ? styles.closed : ''}`}>
+      <aside
+        ref={sidebarRef}
+        className={`${styles.sidebar} ${!open ? styles.closed : ''}`}
+      >
         <div>
           <div className={styles.logoContainer}>
             <img src={logo} alt="MediTrack logo" className={styles.logo} />

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-const version = '0.1.0008';
+const version = '0.1.0010';
 export default version;


### PR DESCRIPTION
## Summary
- tweak sidebar gradient and add contrasting logo panel
- add click-outside hook to auto close the sidebar
- bump version to 0.1.0010
- document sidebar update in CHANGELOG and README

## Testing
- `npm run lint`
- `npx prettier --write src/layout/Sidebar.tsx src/layout/Sidebar.module.css src/hooks/useOutsideClick.ts src/version.ts CHANGELOG.md README.md`


------
https://chatgpt.com/codex/tasks/task_e_6862f51ddf388331a104ecaa92623c8f