### PR TITLE
Update sidebar with new MediTrack branding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,3 +47,4 @@
 - 2025-06-30 21:52 · Add Firebase anonymous auth and Firestore-based schedule syncing · v0.1.0012
 - 2025-06-30 22:29 · Unspecified task · v0.1.0013
 - 2025-06-30 22:40 · Enable anonymous Firebase Auth and auto-sign-in · v0.1.0014
+- 2025-06-30 23:24 · Unspecified task · v0.1.0015

--- a/README.md
+++ b/README.md
@@ -127,3 +127,4 @@ The MediTrack team
 - 2025-06-30 21:52 · Add Firebase anonymous auth and Firestore-based schedule syncing · v0.1.0012
 - 2025-06-30 22:29 · Unspecified task · v0.1.0013
 - 2025-06-30 22:40 · Enable anonymous Firebase Auth and auto-sign-in · v0.1.0014
+- 2025-06-30 23:24 · Unspecified task · v0.1.0015

--- a/src/index.css
+++ b/src/index.css
@@ -5,8 +5,10 @@
 
   --bg-base: #f7f9fa;
   --text-main: #1f2937;
-  --accent-primary: #10b981;
-  --hover-bg: #d1fae5;
+  /* MediTrack brand colors */
+  --accent-primary: #15b39c;
+  --accent-secondary: #f37ada;
+  --hover-bg: #d0f3ed;
 
   color-scheme: light;
   color: var(--text-main);

--- a/src/layout/Sidebar.module.css
+++ b/src/layout/Sidebar.module.css
@@ -2,13 +2,13 @@
   position: fixed;
   top: 0;
   left: 0;
-  width: 250px;
+  width: min(80vw, 250px);
   height: 100vh;
   background: linear-gradient(
     180deg,
-    #ecfdf5 0%,
-    var(--accent-primary) 40%,
-    #059669 100%
+    #f0fdfa 0%,
+    var(--accent-primary) 60%,
+    #0e766c 100%
   );
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
   padding: 1rem;
@@ -28,6 +28,7 @@
 .logoContainer {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 0.75rem;
   margin-bottom: 1.5rem;
   padding: 0.75rem 1rem;
@@ -43,7 +44,8 @@
 }
 
 .logo {
-  width: 160px;
+  width: 100%;
+  max-width: 160px;
   height: auto;
 }
 
@@ -73,8 +75,8 @@
 
 .active {
   font-weight: 700;
-  background: #e2e8f0;
-  color: var(--text-main);
+  background: var(--accent-secondary);
+  color: #ffffff;
 }
 
 .version {
@@ -118,7 +120,7 @@
 }
 
 .buttonOpen {
-  left: 260px;
+  left: calc(min(80vw, 250px) + 10px);
 }
 
 .icon {

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -4,7 +4,7 @@ import { FaHome, FaSyringe, FaPlane, FaCog } from 'react-icons/fa';
 import { GiMedicines } from 'react-icons/gi';
 import { MdMenu, MdClose } from 'react-icons/md';
 import version from '../version';
-import logo from '../assets/meditrack-logo-horizontal.png';
+import logo from '../assets/MediTrack_logo_svg.svg';
 import styles from './Sidebar.module.css';
 import useOutsideClick from '../hooks/useOutsideClick';
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-const version = '0.1.0014';
+const version = '0.1.0015';
 export default version;


### PR DESCRIPTION
## Summary
- add MediTrack green and pink as CSS variables
- swap sidebar logo to new SVG
- lighten sidebar gradient and make width responsive
- style active links with the pink accent

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68631c7263cc8331b7d825d14c52519f