### PR TITLE
Fix share modal listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,3 +51,4 @@
 - 2025-06-30 23:33 · Unspecified task · v0.1.0016
 
 - 2025-06-30 23:34 · Fix null element error in share-modal.js using safe event listener attachment · v0.1.0017
+- 2025-06-30 23:41 · Unspecified task · v0.1.0018

--- a/README.md
+++ b/README.md
@@ -131,3 +131,4 @@ The MediTrack team
 - 2025-06-30 23:33 · Unspecified task · v0.1.0016
 
 - 2025-06-30 23:34 · Fix null element error in share-modal.js using safe event listener attachment · v0.1.0017
+- 2025-06-30 23:41 · Unspecified task · v0.1.0018

--- a/public/share-modal.js
+++ b/public/share-modal.js
@@ -1,10 +1,17 @@
-document.addEventListener('DOMContentLoaded', () => {
-  const shareBtn = document.getElementById('share-button');
-  if (!shareBtn) return;
-  shareBtn.addEventListener('click', () => {
-    const modal = document.getElementById('share-modal');
-    if (modal) {
-      modal.classList.add('open');
+function attachShareModalListener() {
+  document.addEventListener('click', (event) => {
+    const target = event.target;
+    if (target && target.id === 'share-button') {
+      const modal = document.getElementById('share-modal');
+      if (modal) {
+        modal.classList.add('open');
+      }
     }
   });
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', attachShareModalListener);
+} else {
+  attachShareModalListener();
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-const version = '0.1.0017';
+const version = '0.1.0018';
 export default version;


### PR DESCRIPTION
## Summary
- safely attach click listener for opening the share modal

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68632051d6708331bf2be16038e49922