### PR TITLE
Add null-safe share modal script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,3 +56,5 @@
 - 2025-07-01 00:09 · Clean up legacy share-modal.js and refresh color + sidebar layout for MediTrack branding · v0.1.0020
 - 2025-07-01 00:15 · Unspecified task · v0.1.0021
 - 2025-07-01 00:16 · Improve version display layout and styling in sidebar · v0.1.0022
+- 2025-07-01 00:24 · Unspecified task · v0.1.0023
+- 2025-07-01 00:25 · Reintroduce share-modal.js with null-safe listener · v0.1.0024

--- a/README.md
+++ b/README.md
@@ -136,3 +136,5 @@ The MediTrack team
 - 2025-07-01 00:09 · Clean up legacy share-modal.js and refresh color + sidebar layout for MediTrack branding · v0.1.0020
 - 2025-07-01 00:15 · Unspecified task · v0.1.0021
 - 2025-07-01 00:16 · Improve version display layout and styling in sidebar · v0.1.0022
+- 2025-07-01 00:24 · Unspecified task · v0.1.0023
+- 2025-07-01 00:25 · Reintroduce share-modal.js with null-safe listener · v0.1.0024

--- a/public/share-modal.js
+++ b/public/share-modal.js
@@ -1,0 +1,16 @@
+function attachShareModalListener() {
+  const button = document.getElementById('share-button');
+  const modal = document.getElementById('share-modal');
+  if (button && modal) {
+    button.addEventListener('click', () => {
+      modal.classList.add('open');
+    });
+  }
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', attachShareModalListener);
+} else {
+  attachShareModalListener();
+}
+

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-const version = '0.1.0022';
+const version = '0.1.0024';
 export default version;


### PR DESCRIPTION
## Summary
- add defensive `public/share-modal.js` script
- bump version to 0.1.0024
- document change in README and CHANGELOG

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686329b70ba08331bf1cc09df35c84fe