### PR TITLE
Add email/password signup & login with account linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,3 +58,5 @@
 - 2025-07-01 00:16 · Improve version display layout and styling in sidebar · v0.1.0022
 - 2025-07-01 00:24 · Unspecified task · v0.1.0023
 - 2025-07-01 00:25 · Reintroduce share-modal.js with null-safe listener · v0.1.0024
+- 2025-07-01 00:45 · Unspecified task · v0.1.0025
+- 2025-07-01 00:48 · Add email/password signup and login with anonymous account linking · v0.1.0026

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ MediTrack is a self‑hosted medical tracking app built with **React** and **Typ
 - Redux Toolkit with redux‑persist
 - react‑router for navigation
 - react‑icons for UI icons
-- Firebase anonymous authentication for schedule syncing
+- Firebase anonymous authentication for schedule syncing, with optional email/password accounts
 
 ## Features
 
@@ -138,3 +138,5 @@ The MediTrack team
 - 2025-07-01 00:16 · Improve version display layout and styling in sidebar · v0.1.0022
 - 2025-07-01 00:24 · Unspecified task · v0.1.0023
 - 2025-07-01 00:25 · Reintroduce share-modal.js with null-safe listener · v0.1.0024
+- 2025-07-01 00:45 · Unspecified task · v0.1.0025
+- 2025-07-01 00:48 · Add email/password signup and login with anonymous account linking · v0.1.0026

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,8 @@ import InjectionSchedule from './pages/InjectionSchedule';
 import OralSchedule from './pages/OralSchedule';
 import TravelPlans from './pages/TravelPlans';
 import Config from './pages/Config';
+import Signup from './components/Auth/Signup';
+import Login from './components/Auth/Login';
 
 function App() {
   return (
@@ -18,6 +20,8 @@ function App() {
             <Route path="/oral" element={<OralSchedule />} />
             <Route path="/travel" element={<TravelPlans />} />
             <Route path="/config" element={<Config />} />
+            <Route path="/signup" element={<Signup />} />
+            <Route path="/login" element={<Login />} />
           </Routes>
         </main>
       </div>

--- a/src/UserContext.tsx
+++ b/src/UserContext.tsx
@@ -1,20 +1,27 @@
 import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import type { User } from 'firebase/auth';
 import { initFirebaseAuth } from './firebase/firebase';
 
 interface UserState {
+  user: User | null;
   uid: string | null;
   loading: boolean;
 }
-
-const UserContext = createContext<UserState>({ uid: null, loading: true });
+const UserContext = createContext<UserState>({
+  user: null,
+  uid: null,
+  loading: true,
+});
 
 export function UserProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
   const [uid, setUid] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const unsubscribe = initFirebaseAuth((id) => {
-      setUid(id);
+    const unsubscribe = initFirebaseAuth((usr) => {
+      setUser(usr);
+      setUid(usr ? usr.uid : null);
       setLoading(false);
     });
     return () => {
@@ -24,7 +31,7 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
     };
   }, []);
 
-  const value = useMemo(() => ({ uid, loading }), [uid, loading]);
+  const value = useMemo(() => ({ user, uid, loading }), [user, uid, loading]);
   return <UserContext.Provider value={value}>{children}</UserContext.Provider>;
 }
 

--- a/src/components/Auth/Login.tsx
+++ b/src/components/Auth/Login.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { loginWithEmail } from '../../firebase/firebase';
+
+function Login() {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+    try {
+      await loginWithEmail(email, password);
+      navigate('/');
+    } catch (err: unknown) {
+      if (err instanceof Error) setError(err.message);
+      else setError(String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="mx-auto mt-10 flex max-w-sm flex-col space-y-4"
+    >
+      <input
+        type="email"
+        className="rounded border p-2"
+        placeholder="Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+      />
+      <input
+        type="password"
+        className="rounded border p-2"
+        placeholder="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        required
+      />
+      {error && <div className="text-red-600">{error}</div>}
+      <button
+        type="submit"
+        disabled={loading}
+        className="rounded bg-teal-600 p-2 text-white disabled:opacity-60"
+      >
+        {loading ? 'Signing in...' : 'Login'}
+      </button>
+    </form>
+  );
+}
+
+export default Login;

--- a/src/components/Auth/Signup.tsx
+++ b/src/components/Auth/Signup.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { signUpWithEmail } from '../../firebase/firebase';
+
+function Signup() {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+    try {
+      await signUpWithEmail(email, password);
+      navigate('/');
+    } catch (err: unknown) {
+      if (err instanceof Error) setError(err.message);
+      else setError(String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="mx-auto mt-10 flex max-w-sm flex-col space-y-4"
+    >
+      <input
+        type="email"
+        className="rounded border p-2"
+        placeholder="Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+      />
+      <input
+        type="password"
+        className="rounded border p-2"
+        placeholder="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        required
+      />
+      {error && <div className="text-red-600">{error}</div>}
+      <button
+        type="submit"
+        disabled={loading}
+        className="rounded bg-teal-600 p-2 text-white disabled:opacity-60"
+      >
+        {loading ? 'Creating account...' : 'Sign Up'}
+      </button>
+    </form>
+  );
+}
+
+export default Signup;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-const version = '0.1.0024';
+const version = '0.1.0026';
 export default version;


### PR DESCRIPTION
## Summary
- implement email/password auth with anonymous account linking
- expose auth helpers in firebase module
- track full Firebase user in context
- add simple signup/login forms
- route `/signup` and `/login`
- document new auth option
- bump version to v0.1.0026

## Testing
- `npm run lint`
- `npm run format`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68632f5d118c83319324e8fd17ba6fdc