### PR TITLE
Add AuthStatus component with logout button for Firebase auth testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,3 +60,5 @@
 - 2025-07-01 00:25 · Reintroduce share-modal.js with null-safe listener · v0.1.0024
 - 2025-07-01 00:45 · Unspecified task · v0.1.0025
 - 2025-07-01 00:48 · Add email/password signup and login with anonymous account linking · v0.1.0026
+- 2025-07-01 00:57 · Unspecified task · v0.1.0027
+- 2025-07-01 01:05 · Add AuthStatus component with logout button for Firebase auth testing · v0.1.0028

--- a/README.md
+++ b/README.md
@@ -140,3 +140,5 @@ The MediTrack team
 - 2025-07-01 00:25 · Reintroduce share-modal.js with null-safe listener · v0.1.0024
 - 2025-07-01 00:45 · Unspecified task · v0.1.0025
 - 2025-07-01 00:48 · Add email/password signup and login with anonymous account linking · v0.1.0026
+- 2025-07-01 00:57 · Unspecified task · v0.1.0027
+- 2025-07-01 01:05 · Add AuthStatus component with logout button for Firebase auth testing · v0.1.0028

--- a/src/components/AuthStatus.tsx
+++ b/src/components/AuthStatus.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { onAuthStateChanged, signOut, type User } from 'firebase/auth';
+import { auth } from '../firebase/firebase';
+
+function AuthStatus() {
+  const [user, setUser] = useState<User | null>(auth.currentUser);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, setUser);
+    return () => unsubscribe();
+  }, []);
+
+  if (!user) {
+    return (
+      <div className="text-gray-700 text-sm flex items-center gap-2">
+        <span>Signed in: None</span>
+        <button
+          type="button"
+          className="text-blue-600 underline"
+          onClick={() => {}}
+        >
+          Login
+        </button>
+      </div>
+    );
+  }
+
+  const label = user.email || (user.isAnonymous ? 'Anonymous' : 'Unknown');
+
+  return (
+    <div className="text-gray-700 text-sm flex items-center gap-2">
+      <span>Signed in: {label}</span>
+      <button
+        type="button"
+        className="text-blue-600 underline"
+        onClick={() => signOut(auth)}
+      >
+        Logout
+      </button>
+    </div>
+  );
+}
+
+export default AuthStatus;

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -5,6 +5,7 @@ import { GiMedicines } from 'react-icons/gi';
 import { MdMenu, MdClose } from 'react-icons/md';
 import version from '../version';
 import logo from '../assets/MediTrack_logo_svg.svg';
+import AuthStatus from '../components/AuthStatus';
 import styles from './Sidebar.module.css';
 import useOutsideClick from '../hooks/useOutsideClick';
 
@@ -130,7 +131,12 @@ function Sidebar() {
             >
               <FaCog /> Configuration
             </NavLink>
-            <div className="mt-6 text-center text-sm text-gray-500">v{version}</div>
+            <div className="mt-4">
+              <AuthStatus />
+            </div>
+            <div className="mt-6 text-center text-sm text-gray-500">
+              v{version}
+            </div>
           </nav>
         </div>
       </aside>

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-const version = '0.1.0026';
+const version = '0.1.0028';
 export default version;


### PR DESCRIPTION
## Summary
- add new AuthStatus component displaying sign in state
- display AuthStatus in the sidebar
- bump version number
- document change in CHANGELOG and README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6863324a9e0c8331a6c33ce260b0ae4b