### PR TITLE
Implement email/password login form and logout flow with auth state management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,3 +62,5 @@
 - 2025-07-01 00:48 · Add email/password signup and login with anonymous account linking · v0.1.0026
 - 2025-07-01 00:57 · Unspecified task · v0.1.0027
 - 2025-07-01 01:05 · Add AuthStatus component with logout button for Firebase auth testing · v0.1.0028
+- 2025-07-01 01:25 · Unspecified task · v0.1.0029
+- 2025-07-01 01:28 · Implement email/password login form and logout flow with auth state management · v0.1.0030

--- a/README.md
+++ b/README.md
@@ -142,3 +142,5 @@ The MediTrack team
 - 2025-07-01 00:48 · Add email/password signup and login with anonymous account linking · v0.1.0026
 - 2025-07-01 00:57 · Unspecified task · v0.1.0027
 - 2025-07-01 01:05 · Add AuthStatus component with logout button for Firebase auth testing · v0.1.0028
+- 2025-07-01 01:25 · Unspecified task · v0.1.0029
+- 2025-07-01 01:28 · Implement email/password login form and logout flow with auth state management · v0.1.0030

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,9 +6,24 @@ import OralSchedule from './pages/OralSchedule';
 import TravelPlans from './pages/TravelPlans';
 import Config from './pages/Config';
 import Signup from './components/Auth/Signup';
-import Login from './components/Auth/Login';
+import LoginForm from './components/Auth/LoginForm';
+import { useUser } from './UserContext';
 
 function App() {
+  const { user, loading } = useUser();
+
+  if (loading) {
+    return <div className="p-4">Loading...</div>;
+  }
+
+  if (!user) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gray-100 p-4">
+        <LoginForm />
+      </div>
+    );
+  }
+
   return (
     <Router>
       <div style={{ display: 'flex' }}>
@@ -21,7 +36,6 @@ function App() {
             <Route path="/travel" element={<TravelPlans />} />
             <Route path="/config" element={<Config />} />
             <Route path="/signup" element={<Signup />} />
-            <Route path="/login" element={<Login />} />
           </Routes>
         </main>
       </div>

--- a/src/components/Auth/LoginForm.tsx
+++ b/src/components/Auth/LoginForm.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import { signInWithEmailAndPassword } from 'firebase/auth';
+import { auth } from '../../firebase/firebase';
+
+function LoginForm() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    if (!email || !password) {
+      setError('Email and password are required');
+      return;
+    }
+    setLoading(true);
+    try {
+      await signInWithEmailAndPassword(auth, email, password);
+    } catch (err: unknown) {
+      if (err instanceof Error) setError(err.message);
+      else setError(String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="mx-auto flex max-w-sm flex-col space-y-3 rounded border bg-white p-4 shadow"
+    >
+      <input
+        type="email"
+        className="rounded border p-2"
+        placeholder="Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+      />
+      <input
+        type="password"
+        className="rounded border p-2"
+        placeholder="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        required
+      />
+      {error && <div className="text-sm text-red-600">{error}</div>}
+      <button
+        type="submit"
+        disabled={loading}
+        className="rounded bg-teal-600 p-2 text-white disabled:opacity-60"
+      >
+        {loading ? 'Signing in...' : 'Login'}
+      </button>
+    </form>
+  );
+}
+
+export default LoginForm;

--- a/src/components/AuthStatus.tsx
+++ b/src/components/AuthStatus.tsx
@@ -1,26 +1,31 @@
 import { useEffect, useState } from 'react';
 import { onAuthStateChanged, signOut, type User } from 'firebase/auth';
 import { auth } from '../firebase/firebase';
+import LoginForm from './Auth/LoginForm';
 
 function AuthStatus() {
   const [user, setUser] = useState<User | null>(auth.currentUser);
+  const [showLogin, setShowLogin] = useState(false);
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, setUser);
+    const unsubscribe = onAuthStateChanged(auth, (usr) => {
+      setUser(usr);
+      if (usr) setShowLogin(false);
+    });
     return () => unsubscribe();
   }, []);
 
   if (!user) {
     return (
-      <div className="text-gray-700 text-sm flex items-center gap-2">
-        <span>Signed in: None</span>
+      <div className="flex flex-col items-start gap-2 text-sm text-gray-700">
         <button
           type="button"
           className="text-blue-600 underline"
-          onClick={() => {}}
+          onClick={() => setShowLogin((v) => !v)}
         >
-          Login
+          {showLogin ? 'Close' : 'Login'}
         </button>
+        {showLogin && <LoginForm />}
       </div>
     );
   }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-const version = '0.1.0028';
+const version = '0.1.0030';
 export default version;


### PR DESCRIPTION
## Summary
- add LoginForm component using Firebase email/password auth
- toggle login form from the sidebar AuthStatus component
- show login form by default when no user is signed in
- bump version to v0.1.0030
- document changes in CHANGELOG and README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6863389c6058833194b1a205510a01d6