### PR TITLE
Add login screen for anonymous and email auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,3 +64,5 @@
 - 2025-07-01 01:05 · Add AuthStatus component with logout button for Firebase auth testing · v0.1.0028
 - 2025-07-01 01:25 · Unspecified task · v0.1.0029
 - 2025-07-01 01:28 · Implement email/password login form and logout flow with auth state management · v0.1.0030
+- 2025-07-01 01:34 · Unspecified task · v0.1.0031
+- 2025-07-01 01:38 · Add branded login screen with anonymous and email/password auth options · v0.1.0032

--- a/README.md
+++ b/README.md
@@ -144,3 +144,5 @@ The MediTrack team
 - 2025-07-01 01:05 · Add AuthStatus component with logout button for Firebase auth testing · v0.1.0028
 - 2025-07-01 01:25 · Unspecified task · v0.1.0029
 - 2025-07-01 01:28 · Implement email/password login form and logout flow with auth state management · v0.1.0030
+- 2025-07-01 01:34 · Unspecified task · v0.1.0031
+- 2025-07-01 01:38 · Add branded login screen with anonymous and email/password auth options · v0.1.0032

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import OralSchedule from './pages/OralSchedule';
 import TravelPlans from './pages/TravelPlans';
 import Config from './pages/Config';
 import Signup from './components/Auth/Signup';
-import LoginForm from './components/Auth/LoginForm';
+import LoginScreen from './components/Auth/LoginScreen';
 import { useUser } from './UserContext';
 
 function App() {
@@ -19,7 +19,7 @@ function App() {
   if (!user) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-gray-100 p-4">
-        <LoginForm />
+        <LoginScreen />
       </div>
     );
   }

--- a/src/components/Auth/LoginScreen.tsx
+++ b/src/components/Auth/LoginScreen.tsx
@@ -1,0 +1,144 @@
+import { useState } from 'react';
+import {
+  signInAnonymously,
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+} from 'firebase/auth';
+import { auth } from '../../firebase/firebase';
+import logo from '../../assets/meditrack-logo-horizontal.png';
+
+function LoginScreen() {
+  const [mode, setMode] = useState<'anon' | 'email'>('anon');
+  const [emailMode, setEmailMode] = useState<'login' | 'signup'>('login');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+  let submitLabel = '';
+  if (loading) {
+    submitLabel = emailMode === 'signup' ? 'Creating account...' : 'Signing in...';
+  } else {
+    submitLabel = emailMode === 'signup' ? 'Sign Up' : 'Login';
+  }
+
+  const handleAnon = async () => {
+    setError('');
+    setLoading(true);
+    try {
+      await signInAnonymously(auth);
+    } catch (err: unknown) {
+      if (err instanceof Error) setError(err.message);
+      else setError(String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleEmail = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!email || !password) {
+      setError('Email and password are required');
+      return;
+    }
+    setError('');
+    setLoading(true);
+    try {
+      if (emailMode === 'signup') {
+        await createUserWithEmailAndPassword(auth, email, password);
+      } else {
+        await signInWithEmailAndPassword(auth, email, password);
+      }
+    } catch (err: unknown) {
+      if (err instanceof Error) setError(err.message);
+      else setError(String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const activeTab =
+    'px-4 py-2 font-medium rounded-t border-b-2 border-accent-primary text-accent-primary';
+  const inactiveTab =
+    'px-4 py-2 font-medium rounded-t border-b-2 border-transparent text-gray-500 hover:text-accent-primary';
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100 p-4">
+      <div className="w-full max-w-md bg-white rounded shadow-lg p-6">
+        <img src={logo} alt="MediTrack logo" className="mx-auto mb-6 w-48" />
+        <div className="flex justify-center mb-6 space-x-4 border-b">
+          <button
+            type="button"
+            className={mode === 'anon' ? activeTab : inactiveTab}
+            onClick={() => setMode('anon')}
+          >
+            Anonymous
+          </button>
+          <button
+            type="button"
+            className={mode === 'email' ? activeTab : inactiveTab}
+            onClick={() => setMode('email')}
+          >
+            Email Login
+          </button>
+        </div>
+        {mode === 'anon' && (
+          <div className="text-center">
+            {error && <div className="mb-4 text-sm text-red-600">{error}</div>}
+            <button
+              type="button"
+              onClick={handleAnon}
+              disabled={loading}
+              className="w-full rounded bg-accent-primary py-2 text-white disabled:opacity-60"
+            >
+              {loading ? 'Signing in...' : 'Continue Anonymously'}
+            </button>
+          </div>
+        )}
+        {mode === 'email' && (
+          <form
+            onSubmit={handleEmail}
+            className="flex flex-col space-y-3"
+          >
+            <input
+              type="email"
+              className="rounded border p-2"
+              placeholder="Email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+            <input
+              type="password"
+              className="rounded border p-2"
+              placeholder="Password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+            {error && <div className="text-sm text-red-600">{error}</div>}
+            <button
+              type="submit"
+              disabled={loading}
+              className="rounded bg-accent-primary p-2 text-white disabled:opacity-60"
+            >
+              {submitLabel}
+            </button>
+            <button
+              type="button"
+              className="text-sm text-accent-secondary underline mt-1"
+              onClick={() =>
+                setEmailMode((m) => (m === 'login' ? 'signup' : 'login'))
+              }
+            >
+              {emailMode === 'login'
+                ? "Don't have an account? Sign up"
+                : 'Already have an account? Login'}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default LoginScreen;

--- a/src/firebase/firebase.ts
+++ b/src/firebase/firebase.ts
@@ -37,11 +37,9 @@ setPersistence(auth, browserLocalPersistence).catch((err) => {
   console.error('Failed to set persistence:', err);
 });
 
-// Sign in anonymously on startup if no user is signed in
-if (!auth.currentUser) {
-  signInAnonymously(auth).catch((err) => {
-    console.error('Anonymous sign-in failed:', err);
-  });
+// Manual anonymous sign-in is triggered from the login screen
+export function loginAnonymously() {
+  return signInAnonymously(auth);
 }
 
 // Listen for auth state changes

--- a/src/index.css
+++ b/src/index.css
@@ -72,3 +72,20 @@ button:focus-visible {
 .sidebar-gradient {
   background: var(--sidebar-gradient);
 }
+
+/* Utility classes for brand colors */
+.bg-accent-primary {
+  background-color: var(--accent-primary);
+}
+
+.text-accent-primary {
+  color: var(--accent-primary);
+}
+
+.text-accent-secondary {
+  color: var(--accent-secondary);
+}
+
+.border-accent-primary {
+  border-color: var(--accent-primary);
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-const version = '0.1.0030';
+const version = '0.1.0032';
 export default version;


### PR DESCRIPTION
## Summary
- create `LoginScreen` with anonymous sign-in, email login, and signup
- update Firebase helper to remove auto anon login and export `loginAnonymously`
- expose brand color utility classes in `index.css`
- show `LoginScreen` in `App` when user isn't logged in
- bump version to v0.1.0032
- update changelog and readme

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68633aeb80788331895d4a5af8eb1dfb