### PR TITLE
Redesign login flow and isolate user data in Firebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,3 +66,5 @@
 - 2025-07-01 01:28 · Implement email/password login form and logout flow with auth state management · v0.1.0030
 - 2025-07-01 01:34 · Unspecified task · v0.1.0031
 - 2025-07-01 01:38 · Add branded login screen with anonymous and email/password auth options · v0.1.0032
+- 2025-07-01 01:50 · Unspecified task · v0.1.0033
+- 2025-07-01 01:54 · Redesign login flow and isolate user data in Firebase · v0.1.0034

--- a/README.md
+++ b/README.md
@@ -146,3 +146,5 @@ The MediTrack team
 - 2025-07-01 01:28 · Implement email/password login form and logout flow with auth state management · v0.1.0030
 - 2025-07-01 01:34 · Unspecified task · v0.1.0031
 - 2025-07-01 01:38 · Add branded login screen with anonymous and email/password auth options · v0.1.0032
+- 2025-07-01 01:50 · Unspecified task · v0.1.0033
+- 2025-07-01 01:54 · Redesign login flow and isolate user data in Firebase · v0.1.0034

--- a/src/components/AuthStatus.tsx
+++ b/src/components/AuthStatus.tsx
@@ -1,33 +1,12 @@
-import { useEffect, useState } from 'react';
-import { onAuthStateChanged, signOut, type User } from 'firebase/auth';
+import { signOut } from 'firebase/auth';
 import { auth } from '../firebase/firebase';
-import LoginForm from './Auth/LoginForm';
+import { useUser } from '../UserContext';
 
 function AuthStatus() {
-  const [user, setUser] = useState<User | null>(auth.currentUser);
-  const [showLogin, setShowLogin] = useState(false);
-
-  useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (usr) => {
-      setUser(usr);
-      if (usr) setShowLogin(false);
-    });
-    return () => unsubscribe();
-  }, []);
+  const { user } = useUser();
 
   if (!user) {
-    return (
-      <div className="flex flex-col items-start gap-2 text-sm text-gray-700">
-        <button
-          type="button"
-          className="text-blue-600 underline"
-          onClick={() => setShowLogin((v) => !v)}
-        >
-          {showLogin ? 'Close' : 'Login'}
-        </button>
-        {showLogin && <LoginForm />}
-      </div>
-    );
+    return null;
   }
 
   const label = user.email || (user.isAnonymous ? 'Anonymous' : 'Unknown');

--- a/src/firebase/firebase.ts
+++ b/src/firebase/firebase.ts
@@ -10,6 +10,11 @@ import {
   EmailAuthProvider,
   setPersistence,
   browserLocalPersistence,
+  GoogleAuthProvider,
+  FacebookAuthProvider,
+  signInWithPopup,
+  linkWithPopup,
+  sendPasswordResetEmail,
   type User,
 } from 'firebase/auth';
 import type { FirebaseError } from 'firebase/app';
@@ -110,4 +115,48 @@ export async function loginWithEmail(email: string, password: string) {
   }
   const res = await signInWithEmailAndPassword(auth, email, password);
   return res.user;
+}
+
+// Social login with Google
+export async function loginWithGoogle() {
+  const provider = new GoogleAuthProvider();
+  if (auth.currentUser && auth.currentUser.isAnonymous) {
+    try {
+      const res = await linkWithPopup(auth.currentUser, provider);
+      return res.user;
+    } catch (err: unknown) {
+      const { code } = err as FirebaseError;
+      if (code === 'auth/credential-already-in-use') {
+        const userCred = await signInWithPopup(auth, provider);
+        return userCred.user;
+      }
+      throw err;
+    }
+  }
+  const res = await signInWithPopup(auth, provider);
+  return res.user;
+}
+
+// Social login with Facebook
+export async function loginWithFacebook() {
+  const provider = new FacebookAuthProvider();
+  if (auth.currentUser && auth.currentUser.isAnonymous) {
+    try {
+      const res = await linkWithPopup(auth.currentUser, provider);
+      return res.user;
+    } catch (err: unknown) {
+      const { code } = err as FirebaseError;
+      if (code === 'auth/credential-already-in-use') {
+        const userCred = await signInWithPopup(auth, provider);
+        return userCred.user;
+      }
+      throw err;
+    }
+  }
+  const res = await signInWithPopup(auth, provider);
+  return res.user;
+}
+
+export function resetPassword(email: string) {
+  return sendPasswordResetEmail(auth, email);
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-const version = '0.1.0032';
+const version = '0.1.0034';
 export default version;


### PR DESCRIPTION
## Summary
- refresh LoginScreen with MediTrack branding
- support signup, login, social auth and anonymous auth
- show signed in user via UserContext
- expose Google/Facebook auth helpers in Firebase layer
- bump version number

## Testing
- `npm run format`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68633e93a4888331a152b45a6802e2aa