### PR TITLE
Scope Firestore access to each user’s UID to isolate data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,3 +68,5 @@
 - 2025-07-01 01:38 · Add branded login screen with anonymous and email/password auth options · v0.1.0032
 - 2025-07-01 01:50 · Unspecified task · v0.1.0033
 - 2025-07-01 01:54 · Redesign login flow and isolate user data in Firebase · v0.1.0034
+- 2025-07-01 02:02 · Unspecified task · v0.1.0035
+- 2025-07-01 02:05 · Scope Firestore access to each user’s UID to isolate data · v0.1.0036

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ MediTrack is a self‑hosted medical tracking app built with **React** and **Typ
 - react‑router for navigation
 - react‑icons for UI icons
 - Firebase anonymous authentication for schedule syncing, with optional email/password accounts
+- Firestore data is stored under each user's UID so schedules remain private
 
 ## Features
 
@@ -73,7 +74,7 @@ The current version is tracked in `src/version.ts`. Each commit bumps the patch 
 
 ## Privacy
 
-MediTrack does not send data anywhere. All configuration and schedules are stored in the browser via `localStorage`.
+All configuration is stored locally in the browser. If you sign in, schedule data is also synced to Firestore under your personal UID.
 
 ## Author
 
@@ -148,3 +149,5 @@ The MediTrack team
 - 2025-07-01 01:38 · Add branded login screen with anonymous and email/password auth options · v0.1.0032
 - 2025-07-01 01:50 · Unspecified task · v0.1.0033
 - 2025-07-01 01:54 · Redesign login flow and isolate user data in Firebase · v0.1.0034
+- 2025-07-01 02:02 · Unspecified task · v0.1.0035
+- 2025-07-01 02:05 · Scope Firestore access to each user’s UID to isolate data · v0.1.0036

--- a/src/firebase/firebase.ts
+++ b/src/firebase/firebase.ts
@@ -1,5 +1,5 @@
 import { initializeApp } from 'firebase/app';
-import { getFirestore, doc, setDoc, getDoc } from 'firebase/firestore';
+import { getFirestore, doc, setDoc, getDoc, deleteDoc } from 'firebase/firestore';
 import {
   getAuth,
   signInAnonymously,
@@ -56,17 +56,25 @@ export function initFirebaseAuth(cb: (user: User | null) => void) {
 
 // Save a schedule to Firestore
 export async function saveSchedule(
-  uid: string,
+  uid: string | undefined,
   drugName: string,
   data: unknown,
 ) {
+  if (!uid) throw new Error('saveSchedule requires a user id');
   await setDoc(doc(db, 'users', uid, 'schedules', drugName), data);
 }
 
 // Load a schedule from Firestore
-export async function loadSchedule(uid: string, drugName: string) {
+export async function loadSchedule(uid: string | undefined, drugName: string) {
+  if (!uid) return null;
   const snap = await getDoc(doc(db, 'users', uid, 'schedules', drugName));
   return snap.exists() ? snap.data() : null;
+}
+
+// Delete a schedule from Firestore
+export async function deleteSchedule(uid: string | undefined, drugName: string) {
+  if (!uid) throw new Error('deleteSchedule requires a user id');
+  await deleteDoc(doc(db, 'users', uid, 'schedules', drugName));
 }
 
 // Create account or link anonymous user to email/password

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-const version = '0.1.0034';
+const version = '0.1.0036';
 export default version;


### PR DESCRIPTION
## Summary
- ensure Firebase schedules are saved/loaded under `users/{uid}`
- note user-specific Firestore storage in README and privacy section
- add version bump and changelog entry

## Testing
- `npm run lint`
- `npm run build`
- `node` Firestore access test *(fails: auth/network-request-failed)*

------
https://chatgpt.com/codex/tasks/task_e_68634161f4f083318dcf5266cb64f7d5