### PR TITLE
Rename TRT Planner to MediTrack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,3 +71,5 @@
 - 2025-07-01 02:02 · Unspecified task · v0.1.0035
 - 2025-07-01 02:05 · Scope Firestore access to each user’s UID to isolate data · v0.1.0036
 - 2025-07-01 08:29 · Unspecified task · v0.1.0037
+- 2025-07-01 10:22 · Unspecified task · v0.1.0038
+- 2025-07-01 10:26 · Rename app from TRT Planner to MediTrack · v0.1.0039

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 MediTrack is a self‑hosted medical tracking app built with **React** and **TypeScript** using Vite. It stores all data locally in the browser and requires no backend services. The app lets you configure medications and plan upcoming doses through interactive calendars.
 
+This project was previously named **TRT Planner**.
+
 ## Tech Stack
 
 - React 19 + TypeScript
@@ -152,3 +154,5 @@ The MediTrack team
 - 2025-07-01 02:02 · Unspecified task · v0.1.0035
 - 2025-07-01 02:05 · Scope Firestore access to each user’s UID to isolate data · v0.1.0036
 - 2025-07-01 08:29 · Unspecified task · v0.1.0037
+- 2025-07-01 10:22 · Unspecified task · v0.1.0038
+- 2025-07-01 10:26 · Rename app from TRT Planner to MediTrack · v0.1.0039

--- a/package.json
+++ b/package.json
@@ -43,5 +43,6 @@
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.34.1",
     "vite": "^7.0.0"
-  }
+  },
+  "description": "Self-hosted medical tracking app"
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-const version = '0.1.0037';
+const version = '0.1.0039';
 export default version;


### PR DESCRIPTION
## Summary
- rename project references to MediTrack
- add note about rename in README
- document rename in changelog
- bump version

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6863b6b41e54833182d2fbe07ef06286