### PR TITLE
Final sweep to remove leftover TRT branding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,3 +75,5 @@
 - 2025-07-01 10:26 · Rename app from TRT Planner to MediTrack · v0.1.0039
 - 2025-07-01 10:33 · Unspecified task · v0.1.0040
 - 2025-07-01 10:34 · Update config and metadata to reflect MediTrack branding · v0.1.0041
+- 2025-07-01 10:49 · Unspecified task · v0.1.0042
+- 2025-07-01 10:51 · Final sweep to remove leftover TRT branding · v0.1.0043

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 MediTrack is a self‑hosted medical tracking app built with **React** and **TypeScript** using Vite. It stores all data locally in the browser and requires no backend services. The app lets you configure medications and plan upcoming doses through interactive calendars.
 
-This project was previously named **TRT Planner**.
-
 ## Tech Stack
 
 - React 19 + TypeScript
@@ -157,3 +155,4 @@ The MediTrack team
 - 2025-07-01 10:22 · Unspecified task · v0.1.0038
 - 2025-07-01 10:26 · Rename app from TRT Planner to MediTrack · v0.1.0039
 - 2025-07-01 10:33 · Unspecified task · v0.1.0040
+- 2025-07-01 10:49 · Unspecified task · v0.1.0042

--- a/src/assets/trt_logo.svg
+++ b/src/assets/trt_logo.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
-  <circle cx="60" cy="60" r="50" fill="#003366"/>
-  <text x="60" y="70" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="45" fill="white">TRT</text>
-</svg>

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-const version = '0.1.0041';
+const version = '0.1.0043';
 export default version;


### PR DESCRIPTION
## Summary
- delete unused TRT logo asset
- remove mention of TRT Planner from README
- bump version to 0.1.0043
- document change in CHANGELOG

## Testing
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6863bcf688b88331bff125eeb015ffec