### PR TITLE
Migrate login form styling from unused SignInForm to live components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,3 +78,4 @@
 - 2025-07-01 10:49 · Unspecified task · v0.1.0042
 - 2025-07-01 10:51 · Final sweep to remove leftover TRT branding · v0.1.0043
 - 2025-07-01 14:35 · Unspecified task · v0.1.0044
+- 2025-07-01 15:13 · Unspecified task · v0.1.0045

--- a/README.md
+++ b/README.md
@@ -71,3 +71,4 @@ Current version: `0.1.0000`
 ## Changelog
 
 - 2025-07-01 14:35 · Unspecified task · v0.1.0044
+- 2025-07-01 15:13 · Unspecified task · v0.1.0045

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,8 +5,8 @@ import InjectionSchedule from './pages/InjectionSchedule';
 import OralSchedule from './pages/OralSchedule';
 import TravelPlans from './pages/TravelPlans';
 import Config from './pages/Config';
-import Signup from './components/Auth/Signup';
-import LoginScreen from './components/Auth/LoginScreen';
+import LoginPage from './pages/LoginPage';
+import SignupPage from './pages/SignupPage';
 import { useUser } from './UserContext';
 
 function App() {
@@ -18,9 +18,12 @@ function App() {
 
   if (!user) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-gray-100 p-4">
-        <LoginScreen />
-      </div>
+      <Router>
+        <Routes>
+          <Route path="/signup" element={<SignupPage />} />
+          <Route path="*" element={<LoginPage />} />
+        </Routes>
+      </Router>
     );
   }
 
@@ -35,7 +38,8 @@ function App() {
             <Route path="/oral" element={<OralSchedule />} />
             <Route path="/travel" element={<TravelPlans />} />
             <Route path="/config" element={<Config />} />
-            <Route path="/signup" element={<Signup />} />
+            <Route path="/signup" element={<SignupPage />} />
+            <Route path="/login" element={<LoginPage />} />
           </Routes>
         </main>
       </div>

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { loginWithEmail } from '../firebase/firebase';
+
+export default function LoginPage() {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+    try {
+      await loginWithEmail(email, password);
+      navigate('/');
+    } catch (err: unknown) {
+      if (err instanceof Error) setError(err.message);
+      else setError(String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-100 p-4">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-[400px] space-y-4 rounded-lg bg-white p-6 shadow"
+      >
+        <h1 className="text-center text-2xl font-semibold">Login</h1>
+        <input
+          type="email"
+          className="w-full rounded border p-2"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <input
+          type="password"
+          className="w-full rounded border p-2"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        {error && <div className="text-sm text-red-600">{error}</div>}
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full rounded bg-teal-600 p-2 text-white disabled:opacity-60"
+        >
+          {loading ? 'Signing in...' : 'Login'}
+        </button>
+        <p className="text-center text-sm">
+          <Link to="/signup" className="text-blue-600 underline">
+            Need an account? Sign up
+          </Link>
+        </p>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { signUpWithEmail } from '../firebase/firebase';
+
+export default function SignupPage() {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+    try {
+      await signUpWithEmail(email, password);
+      navigate('/');
+    } catch (err: unknown) {
+      if (err instanceof Error) setError(err.message);
+      else setError(String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-100 p-4">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-[400px] space-y-4 rounded-lg bg-white p-6 shadow"
+      >
+        <h1 className="text-center text-2xl font-semibold">Sign Up</h1>
+        <input
+          type="email"
+          className="w-full rounded border p-2"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <input
+          type="password"
+          className="w-full rounded border p-2"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        {error && <div className="text-sm text-red-600">{error}</div>}
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full rounded bg-teal-600 p-2 text-white disabled:opacity-60"
+        >
+          {loading ? 'Creating account...' : 'Sign Up'}
+        </button>
+        <p className="text-center text-sm">
+          <Link to="/login" className="text-blue-600 underline">
+            Already have an account? Login
+          </Link>
+        </p>
+      </form>
+    </div>
+  );
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-const version = '0.1.0044';
+const version = '0.1.0045';
 export default version;


### PR DESCRIPTION
## Summary
- add new LoginPage and SignupPage with card-style forms
- update router to use new pages when unauthenticated
- expose login/signup routes while authenticated

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6863fadcd9bc8331a3f1a8199668aab9