### PR TITLE
Update login screen layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,3 +81,4 @@
 - 2025-07-01 15:13 · Unspecified task · v0.1.0045
 - 2025-07-01 15:42 · Unspecified task · v0.1.0046
 - 2025-07-01 15:44 · Redesign login screen to match modern gradient layout with MediTrack logo and styled inputs · v0.1.0047
+- 2025-07-01 19:52 · Unspecified task · v0.1.0048

--- a/README.md
+++ b/README.md
@@ -74,3 +74,4 @@ Current version: `0.1.0047`
 - 2025-07-01 15:13 · Unspecified task · v0.1.0045
 - 2025-07-01 15:42 · Unspecified task · v0.1.0046
 - 2025-07-01 15:44 · Redesign login screen to match modern gradient layout with MediTrack logo and styled inputs · v0.1.0047
+- 2025-07-01 19:52 · Unspecified task · v0.1.0048

--- a/index.html
+++ b/index.html
@@ -1,13 +1,16 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="h-full bg-white">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="MediTrack helps you track medication schedules and dosing." />
+    <meta
+      name="description"
+      content="MediTrack helps you track medication schedules and dosing."
+    />
     <title>MediTrack</title>
   </head>
-  <body>
+  <body class="h-full">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,87 +1,123 @@
-import { useState } from "react";
-import { FiUser, FiLock } from "react-icons/fi";
-import { handleLogin } from "@/services/auth";
-import Logo from "../assets/MediTrack_logo_svg.svg";
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import handleLogin from '../services/auth';
+import Logo from '../assets/MediTrack_logo_svg.svg';
 
-const LoginPage = () => {
-  const [username, setUsername] = useState("");
-  const [password, setPassword] = useState("");
-  const [error, setError] = useState("");
+/* eslint-disable jsx-a11y/label-has-associated-control */
+
+function LoginPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      await handleLogin(username, password);
-      setError("");
-      window.location.href = "/dashboard";
-    } catch (err) {
-      setError("Invalid username or password");
+      await handleLogin(email, password);
+      setError('');
+      window.location.href = '/dashboard';
+    } catch {
+      setError('Invalid username or password');
     }
   };
 
   const loginAsGuest = () => {
-    localStorage.setItem("access_token", "guest_token");
-    window.location.href = "/dashboard";
+    localStorage.setItem('access_token', 'guest_token');
+    window.location.href = '/dashboard';
   };
 
   return (
-    <div className="min-h-screen bg-gray-100 flex items-center justify-center px-4">
-      <div className="max-w-md w-full bg-white p-8 shadow-lg rounded-lg">
-        <div className="flex justify-center mb-6">
-          <img src={Logo} alt="MediTrack Logo" className="h-12" />
-        </div>
-        <h2 className="text-2xl font-semibold text-center text-gray-800 mb-2">
-          Sign in to MediTrack
+    <div className="flex min-h-full flex-1 flex-col justify-center px-6 py-12 lg:px-8">
+      <div className="sm:mx-auto sm:w-full sm:max-w-sm">
+        <img src={Logo} alt="MediTrack" className="mx-auto h-10 w-auto" />
+        <h2 className="mt-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">
+          Sign in to your account
         </h2>
-        {error && <div className="text-red-500 text-sm mb-4">{error}</div>}
-        <form onSubmit={onSubmit} className="space-y-4">
+      </div>
+
+      <div className="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
+        <form onSubmit={onSubmit} className="space-y-6">
           <div>
-            <label className="block text-sm font-medium text-gray-700">Username</label>
-            <div className="mt-1 relative">
-              <FiUser className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" />
-              <input
-                type="text"
-                value={username}
-                onChange={(e) => setUsername(e.target.value)}
-                className="w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-accent-primary focus:border-accent-primary"
-                placeholder="Enter username"
-              />
-            </div>
+            <label
+              className="block text-sm font-medium leading-6 text-gray-900"
+              htmlFor="email"
+            >
+              Email address
+            </label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              autoComplete="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="mt-2 block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
+            />
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-700">Password</label>
-            <div className="mt-1 relative">
-              <FiLock className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" />
-              <input
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                className="w-full pl-10 pr-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-accent-primary focus:border-accent-primary"
-                placeholder="Enter password"
-              />
+            <div className="flex items-center justify-between">
+              <label
+                className="block text-sm font-medium leading-6 text-gray-900"
+                htmlFor="password"
+              >
+                Password
+              </label>
+              <div className="text-sm">
+                <button
+                  type="button"
+                  className="font-semibold text-indigo-600 hover:text-indigo-500"
+                >
+                  Forgot password?
+                </button>
+              </div>
             </div>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              autoComplete="current-password"
+              required
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="mt-2 block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"
+            />
           </div>
+          {error && <div className="text-sm text-red-600">{error}</div>}
 
-          <div className="flex gap-2">
+          <div>
             <button
               type="submit"
-              className="w-full bg-accent-primary hover:bg-hover-bg text-white font-semibold py-2 px-4 rounded"
+              className="flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
             >
-              Sign In
-            </button>
-            <button
-              type="button"
-              onClick={loginAsGuest}
-              className="w-full bg-accent-secondary hover:bg-pink-500 text-white font-semibold py-2 px-4 rounded"
-            >
-              Continue as Guest
+              Sign in
             </button>
           </div>
         </form>
+
+        <div className="mt-4">
+          <button
+            type="button"
+            onClick={loginAsGuest}
+            className="flex w-full justify-center rounded-md bg-accent-secondary px-3 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-pink-500"
+          >
+            Continue as Guest
+          </button>
+        </div>
+
+        <p className="mt-10 text-center text-sm text-gray-500">
+          Not a member?{' '}
+          <Link
+            to="/signup"
+            className="font-semibold text-indigo-600 hover:text-indigo-500"
+          >
+            Create an account
+          </Link>
+        </p>
       </div>
     </div>
   );
-};
+}
 
 export default LoginPage;

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,7 +1,10 @@
-export async function handleLogin(username: string, password: string): Promise<void> {
+export default async function handleLogin(
+  username: string,
+  password: string,
+): Promise<void> {
   if (username === 'admin' && password === 'password') {
-    localStorage.setItem('access_token', 'mock_token')
+    localStorage.setItem('access_token', 'mock_token');
   } else {
-    throw new Error('Invalid credentials')
+    throw new Error('Invalid credentials');
   }
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-const version = '0.1.0047';
+const version = '0.1.0048';
 export default version;


### PR DESCRIPTION
## Summary
- modernize login screen using Tailwind UI layout
- use local MediTrack logo on sign-in page
- export auth login helper as default
- set root html/body classes for full-height layout

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68643c4fb46c833196dd55b2af8a77a1