### PR TITLE
Add bootstrap-based login page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,3 +83,4 @@
 - 2025-07-01 15:44 · Redesign login screen to match modern gradient layout with MediTrack logo and styled inputs · v0.1.0047
 - 2025-07-01 19:52 · Unspecified task · v0.1.0048
 - 2025-07-01 21:52 · Unspecified task · v0.1.0049
+- 2025-07-01 22:45 · Unspecified task · v0.1.0050

--- a/README.md
+++ b/README.md
@@ -76,3 +76,4 @@ Current version: `0.1.0047`
 - 2025-07-01 15:44 · Redesign login screen to match modern gradient layout with MediTrack logo and styled inputs · v0.1.0047
 - 2025-07-01 19:52 · Unspecified task · v0.1.0048
 - 2025-07-01 21:52 · Unspecified task · v0.1.0049
+- 2025-07-01 22:45 · Unspecified task · v0.1.0050

--- a/index.html
+++ b/index.html
@@ -9,6 +9,12 @@
       content="MediTrack helps you track medication schedules and dosing."
     />
     <title>MediTrack</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-EP3Y5o9er9erW9LuoYfo13tVDCqhO14gso0FLm2CcesEI7Pdr7zuXrbrGmo3HYje"
+      crossorigin="anonymous"
+    />
   </head>
   <body class="h-full">
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import InjectionSchedule from './pages/InjectionSchedule';
 import OralSchedule from './pages/OralSchedule';
 import TravelPlans from './pages/TravelPlans';
 import Config from './pages/Config';
-import LoginPage from './pages/LoginPage';
+import BootstrapLogin from './pages/BootstrapLogin';
 import SignupPage from './pages/SignupPage';
 import { useUser } from './UserContext';
 
@@ -21,7 +21,7 @@ function App() {
       <Router>
         <Routes>
           <Route path="/signup" element={<SignupPage />} />
-          <Route path="*" element={<LoginPage />} />
+          <Route path="*" element={<BootstrapLogin />} />
         </Routes>
       </Router>
     );
@@ -39,7 +39,7 @@ function App() {
             <Route path="/travel" element={<TravelPlans />} />
             <Route path="/config" element={<Config />} />
             <Route path="/signup" element={<SignupPage />} />
-            <Route path="/login" element={<LoginPage />} />
+            <Route path="/login" element={<BootstrapLogin />} />
           </Routes>
         </main>
       </div>

--- a/src/pages/BootstrapLogin.css
+++ b/src/pages/BootstrapLogin.css
@@ -1,0 +1,7 @@
+.divider:after,
+.divider:before {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: #eee;
+}

--- a/src/pages/BootstrapLogin.tsx
+++ b/src/pages/BootstrapLogin.tsx
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import handleLogin from '@/services/auth';
+import './BootstrapLogin.css';
+
+export default function BootstrapLogin() {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await handleLogin(email, password);
+      navigate('/dashboard');
+    } catch {
+      alert('Invalid credentials');
+    }
+  };
+
+  return (
+    <section className="vh-100">
+      <div className="container py-5 h-100">
+        <div className="row d-flex align-items-center justify-content-center h-100">
+          <div className="col-md-8 col-lg-7 col-xl-6">
+            <img
+              src="https://mdbcdn.b-cdn.net/img/Photos/new-templates/bootstrap-login-form/draw2.svg"
+              className="img-fluid"
+              alt="Phone"
+            />
+          </div>
+          <div className="col-md-7 col-lg-5 col-xl-5 offset-xl-1">
+            <form onSubmit={onSubmit}>
+              <div className="form-outline mb-4">
+                <input
+                  type="email"
+                  id="email"
+                  className="form-control form-control-lg"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
+                />
+                <label className="form-label" htmlFor="email">
+                  Email address
+                </label>
+              </div>
+              <div className="form-outline mb-4">
+                <input
+                  type="password"
+                  id="password"
+                  className="form-control form-control-lg"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                />
+                <label className="form-label" htmlFor="password">
+                  Password
+                </label>
+              </div>
+              <div className="d-flex justify-content-around align-items-center mb-4">
+                <div className="form-check">
+                  <input
+                    className="form-check-input"
+                    type="checkbox"
+                    id="remember-me"
+                    defaultChecked
+                  />
+                  <label className="form-check-label" htmlFor="remember-me">
+                    Remember me
+                  </label>
+                </div>
+                <a href="#">Forgot password?</a>
+              </div>
+              <button
+                type="submit"
+                className="btn btn-primary btn-lg btn-block"
+              >
+                Sign in
+              </button>
+              <div className="divider d-flex align-items-center my-4">
+                <p className="text-center fw-bold mx-3 mb-0 text-muted">OR</p>
+              </div>
+              <button
+                type="button"
+                className="btn btn-primary btn-lg btn-block"
+                style={{ backgroundColor: '#3b5998' }}
+              >
+                Continue with Facebook
+              </button>
+              <button
+                type="button"
+                className="btn btn-primary btn-lg btn-block"
+                style={{ backgroundColor: '#55acee' }}
+              >
+                Continue with Twitter
+              </button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
-const version = '0.1.0049';
+const version = '0.1.0050';
 export default version;


### PR DESCRIPTION
## Summary
- add a bootstrap login component
- include simple styling for the divider
- wire new login page into app routing
- include Bootstrap CSS in `index.html`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686464c3dd808331a897b064babb8a83